### PR TITLE
ci: CIをチェックのみに変更、dependabotをbunエコシステムに

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,6 +1,6 @@
 version: 2
 updates:
-  - package-ecosystem: "npm"
+  - package-ecosystem: "bun"
     directory: "/"
     schedule:
       interval: "daily"

--- a/.github/workflows/check_code_quality.yml
+++ b/.github/workflows/check_code_quality.yml
@@ -6,41 +6,10 @@ on:
       - main
 
 jobs:
-  format:
-    runs-on: ubuntu-latest
-    steps:
-    - uses: actions/checkout@v4
-      with:
-        ref: ${{ github.head_ref }}
-
-    - name: Setup Bun
-      uses: oven-sh/setup-bun@v2
-      with:
-        bun-version: latest
-
-    - name: Install dependencies
-      run: bun install --frozen-lockfile
-
-    - name: Run formatter
-      run: bun run format
-
-    - name: Commit changes
-      run: |
-        if [ -n "$(git status --porcelain)" ]; then
-          git config --local user.email "github-actions[bot]@users.noreply.github.com"
-          git config --local user.name "github-actions[bot]"
-          git add .
-          git commit -m "style: format code with biome"
-          git push
-        fi
-
   lint:
-    needs: format
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v4
-      with:
-        ref: ${{ github.head_ref }}
 
     - name: Setup Bun
       uses: oven-sh/setup-bun@v2
@@ -54,12 +23,9 @@ jobs:
       run: bun run lint
 
   typecheck:
-    needs: format
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v4
-      with:
-        ref: ${{ github.head_ref }}
 
     - name: Setup Bun
       uses: oven-sh/setup-bun@v2
@@ -73,12 +39,9 @@ jobs:
       run: bun run typecheck
 
   test:
-    needs: format
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v4
-      with:
-        ref: ${{ github.head_ref }}
 
     - name: Setup Bun
       uses: oven-sh/setup-bun@v2


### PR DESCRIPTION
## 概要

CIワークフローのアンチパターンを修正し、ベストプラクティスに従った構成に変更。

## 変更内容

- format jobを削除し、lint/typecheck/testを並列実行
- commit/pushのアンチパターンを廃止（CIはチェックのみ）
- dependabotをnpmからbunエコシステムに変更（lockfile正常更新のため）
- `--frozen-lockfile`で再現性を保証

## 変更の種類

- [x] CI/CD・ビルド関連

## 参考

- [GitHub Actions: How to Automate Code Formatting in Pull Requests](https://peterevans.dev/posts/github-actions-how-to-automate-code-formatting-in-pull-requests/)
- [Dependabot bun lockfile issue](https://github.com/dependabot/dependabot-core/issues/11602)