### PR TITLE
chore: npm Trusted Publishingに移行

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -7,6 +7,7 @@ on:
 jobs:
   publish:
     runs-on: ubuntu-latest
+    environment: release
     permissions:
       id-token: write
       contents: read

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -7,6 +7,9 @@ on:
 jobs:
   publish:
     runs-on: ubuntu-latest
+    permissions:
+      id-token: write
+      contents: read
     steps:
       - name: Checkout code
         uses: actions/checkout@v6
@@ -34,10 +37,8 @@ jobs:
       - name: Setup Node.js for npm publish
         uses: actions/setup-node@v6
         with:
-          node-version: '20'
+          node-version: '22'
           registry-url: 'https://registry.npmjs.org'
 
       - name: Publish package to npm
         run: npm publish --access public
-        env:
-          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}


### PR DESCRIPTION
## Summary

- NPM_TOKENシークレットを使用した認証からOIDC認証（Trusted Publishing）に移行
- セキュリティ向上: 長期トークンの管理が不要に
- Node.jsを22にアップグレード

## 変更内容

- `permissions: id-token: write` を追加（OIDC認証に必要）
- `permissions: contents: read` を追加（checkout用）
- `NODE_AUTH_TOKEN` 環境変数を削除

## 必要な設定

このPRをマージする前に、npmjs.comでTrusted Publisherを設定する必要があります:

1. https://www.npmjs.com/package/@ukwhatn/wikidot/access にアクセス
2. "Trusted publishers" セクションで "Add a trusted publisher" をクリック
3. 以下を設定:
   - Provider: GitHub Actions
   - Owner: ukwhatn
   - Repository: wikidot-ts
   - Workflow filename: publish.yml
   - Environment name: (空欄)

## 参考

- [npm Trusted Publishing docs](https://docs.npmjs.com/trusted-publishers/)
- [GitHub Changelog](https://github.blog/changelog/2025-07-31-npm-trusted-publishing-with-oidc-is-generally-available/)