### PR TITLE
fix: bunup設定を最新API形式に移行

### DIFF
--- a/bunup.config.ts
+++ b/bunup.config.ts
@@ -1,16 +1,26 @@
 import { defineConfig } from 'bunup';
 
-export default defineConfig({
-  entry: {
-    index: './src/index.ts',
-    errors: './src/common/errors/index.ts',
+export default defineConfig([
+  {
+    name: 'index',
+    entry: './src/index.ts',
+    outDir: './dist',
+    format: ['esm', 'cjs'],
+    dts: true,
+    clean: true,
+    minify: false,
+    sourcemap: true,
+    target: 'node',
   },
-  outDir: './dist',
-  format: ['esm', 'cjs'],
-  dts: true,
-  clean: true,
-  minify: false,
-  sourcemap: true,
-  external: [],
-  target: 'node',
-});
+  {
+    name: 'errors',
+    entry: './src/errors.ts',
+    outDir: './dist',
+    format: ['esm', 'cjs'],
+    dts: true,
+    clean: false,
+    minify: false,
+    sourcemap: true,
+    target: 'node',
+  },
+]);

--- a/src/errors.ts
+++ b/src/errors.ts
@@ -1,0 +1,1 @@
+export * from './common/errors';


### PR DESCRIPTION
## Summary

- bunup v0.16.xでentry形式のオブジェクト記法がサポートされなくなったため、複数設定の配列形式に移行
- errorsエントリポイント用に`src/errors.ts`を追加
- 不要な`external: []`を削除

## Test plan

- [x] `bun run build` が成功することを確認
- [x] `bun test` が全て通ることを確認
- [x] `bun run lint` と `bun run typecheck` が通ることを確認