### PR TITLE
fix: dts生成時の型注釈エラーを修正

### DIFF
--- a/src/common/logger.ts
+++ b/src/common/logger.ts
@@ -148,4 +148,4 @@ export function setupConsoleHandler(logger: Logger, level: LogLevel = 'warn'): v
 /**
  * パッケージ全体で使用されるデフォルトロガー
  */
-export const logger = getLogger();
+export const logger: Logger = getLogger();

--- a/src/connector/amc-types.ts
+++ b/src/connector/amc-types.ts
@@ -23,15 +23,25 @@ export interface AMCRequestBody {
 }
 
 /**
- * AMCレスポンススキーマ
+ * AMCレスポンススキーマ（内部）
  */
-export const amcResponseSchema = z
+const _amcResponseSchema = z
   .object({
     status: z.string(),
     body: z.string().optional(),
     message: z.string().optional(),
   })
   .passthrough();
+
+/**
+ * AMCレスポンススキーマの型
+ */
+export type AMCResponseSchema = typeof _amcResponseSchema;
+
+/**
+ * AMCレスポンススキーマ
+ */
+export const amcResponseSchema: AMCResponseSchema = _amcResponseSchema;
 
 /**
  * AMCレスポンス型

--- a/src/util/quick-module.ts
+++ b/src/util/quick-module.ts
@@ -172,8 +172,12 @@ export function pageLookup(siteId: number, query: string): WikidotResultAsync<QM
  * QuickModule API（後方互換性のため維持）
  * @deprecated 代わりに個別の関数（memberLookup, userLookup, pageLookup）を使用してください
  */
-export const QuickModule = {
-  memberLookup,
-  userLookup,
-  pageLookup,
+export const QuickModule: {
+  memberLookup: typeof memberLookup;
+  userLookup: typeof userLookup;
+  pageLookup: typeof pageLookup;
+} = {
+  memberLookup: memberLookup,
+  userLookup: userLookup,
+  pageLookup: pageLookup,
 };


### PR DESCRIPTION
## Summary

dts生成時のisolated declarations関連エラーを修正

- logger.ts: logger変数に明示的型注釈を追加
- amc-types.ts: amcResponseSchemaにZodObject型を明示
- quick-module.ts: QuickModuleオブジェクトに型注釈を追加

## Test plan

- [x] `bun run build` が成功することを確認