### PR TITLE
ci: npm Trusted Publishing用にNode.js 24を使用

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -38,8 +38,8 @@ jobs:
       - name: Setup Node.js for npm publish
         uses: actions/setup-node@v6
         with:
-          node-version: '22'
+          node-version: '24'
           registry-url: 'https://registry.npmjs.org'
 
       - name: Publish package to npm
-        run: npm publish --access public
+        run: npm publish --provenance --access public


### PR DESCRIPTION
## Summary

- Node.js 22 → 24 に変更（npm 11.x同梱）
- `--provenance` フラグを追加

## Background

npm Trusted PublishingのOIDCトークン検証はnpm 11.5.1以上でのみ動作する。
Node.js 22にはnpm 10.xが同梱されているため、npm 11.xが同梱されているNode.js 24に変更。

## References

- https://remarkablemark.org/blog/2025/12/19/npm-trusted-publishing/
- https://eiji.page/blog/npm-trusted-publishing/