### PR TITLE
docs: パッケージ名とResult型の使用例を修正

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -93,20 +93,30 @@ bun run build
 
 ### コアクラス
 
+すべての非同期メソッドは`WikidotResultAsync<T>`を返す。`isOk()`でチェック後、`.value`で値を取得する。
+
 ```typescript
+import { Client } from '@ukwhatn/wikidot';
+
 // Client - メインエントリポイント
-const client = new Client();
-await client.login(username, password);
-await client.user.get("username");
-await client.site.get("scp-jp");
+const clientResult = await Client.create({ username, password });
+if (!clientResult.isOk()) throw new Error('Failed');
+const client = clientResult.value;
 
 // Site - サイト操作
-const site = await client.site.get("scp-jp");
-await site.page.get("page-name");
-await site.pages.search({ category: "*", tags: ["tag1"] });
+const siteResult = await client.site.get("scp-jp");
+if (!siteResult.isOk()) throw new Error('Failed');
+const site = siteResult.value;
+
+// ページ検索
+const pagesResult = await site.pages.search({ category: "*", tags: ["tag1"] });
+if (!pagesResult.isOk()) throw new Error('Failed');
+const pages = pagesResult.value;
 
 // Page - ページ操作
-const page = await site.page.get("page-name");
+const pageResult = await site.page.get("page-name");
+if (!pageResult.isOk()) throw new Error('Failed');
+const page = pageResult.value;
 await page.getSource();
 await page.getVotes();
 ```
@@ -172,8 +182,8 @@ WikidotError (基底)
 
 ### 認証フロー
 
-1. `Client.login(username, password)`
-2. `HTTPAuthentication.login()` → Wikidot ログインエンドポイントへPOST
+1. `Client.create({ username, password })` でクライアント作成
+2. 内部で`login()` → Wikidot ログインエンドポイントへPOST
 3. `WIKIDOT_SESSION_ID` クッキーを抽出
 4. `@loginRequired` デコレータで検証
 

--- a/README.md
+++ b/README.md
@@ -17,30 +17,40 @@ wikidot-tsは、Wikidot APIを操作するためのTypeScriptライブラリで�
 ## インストール
 
 ```bash
-bun add wikidot-ts
+bun add @ukwhatn/wikidot
 ```
 
 または
 
 ```bash
-npm install wikidot-ts
+npm install @ukwhatn/wikidot
 ```
 
 ## 基本的な使い方
 
+このライブラリは`neverthrow`のResult型を使用します。すべての非同期メソッドは`WikidotResultAsync<T>`を返し、`isOk()`で成功を確認後、`.value`で値を取得します。
+
 ### クライアントの作成
 
 ```typescript
-import { Client } from 'wikidot-ts';
+import { Client } from '@ukwhatn/wikidot';
 
 // ログインなしでアクセス（公開情報のみ）
-const client = await Client.create();
+const clientResult = await Client.create();
+if (!clientResult.isOk()) {
+  throw new Error('クライアントの作成に失敗しました');
+}
+const client = clientResult.value;
 
 // ログインしてアクセス
-const authenticatedClient = await Client.create({
+const authClientResult = await Client.create({
   username: 'your_username',
   password: 'your_password',
 });
+if (!authClientResult.isOk()) {
+  throw new Error('ログインに失敗しました');
+}
+const authClient = authClientResult.value;
 ```
 
 ### サイトの取得
@@ -48,10 +58,11 @@ const authenticatedClient = await Client.create({
 ```typescript
 // サイトを取得
 const siteResult = await client.site.get('scp-jp');
-if (siteResult.isOk()) {
-  const site = siteResult.value;
-  console.log(`サイト: ${site.title}`);
+if (!siteResult.isOk()) {
+  throw new Error('サイトの取得に失敗しました');
 }
+const site = siteResult.value;
+console.log(`サイト: ${site.title}`);
 ```
 
 ### ページの操作
@@ -59,19 +70,21 @@ if (siteResult.isOk()) {
 ```typescript
 // ページを検索
 const pagesResult = await site.pages.search({ category: 'scp', tags: ['safe'] });
-if (pagesResult.isOk()) {
-  for (const page of pagesResult.value) {
-    console.log(`${page.fullname}: ${page.title}`);
-  }
+if (!pagesResult.isOk()) {
+  throw new Error('ページの検索に失敗しました');
+}
+for (const page of pagesResult.value) {
+  console.log(`${page.fullname}: ${page.title}`);
 }
 
 // 単一ページを取得
 const pageResult = await site.page.get('scp-001');
-if (pageResult.isOk()) {
-  const page = pageResult.value;
-  console.log(`タイトル: ${page.title}`);
-  console.log(`レーティング: ${page.rating}`);
+if (!pageResult.isOk()) {
+  throw new Error('ページの取得に失敗しました');
 }
+const page = pageResult.value;
+console.log(`タイトル: ${page.title}`);
+console.log(`レーティング: ${page.rating}`);
 ```
 
 ### フォーラムの操作
@@ -79,36 +92,39 @@ if (pageResult.isOk()) {
 ```typescript
 // フォーラムカテゴリを取得
 const categoriesResult = await site.forum.getCategories();
-if (categoriesResult.isOk()) {
-  for (const category of categoriesResult.value) {
-    console.log(`カテゴリ: ${category.title}`);
-  }
+if (!categoriesResult.isOk()) {
+  throw new Error('フォーラムカテゴリの取得に失敗しました');
+}
+for (const category of categoriesResult.value) {
+  console.log(`カテゴリ: ${category.title}`);
 }
 
 // スレッドに返信（要ログイン）
 const threadResult = await site.forum.getThread(12345);
-if (threadResult.isOk()) {
-  const thread = threadResult.value;
-  await thread.reply('返信内容', 'Re: タイトル');
+if (!threadResult.isOk()) {
+  throw new Error('スレッドの取得に失敗しました');
 }
+const thread = threadResult.value;
+await thread.reply('返信内容', 'Re: タイトル');
 ```
 
 ### プライベートメッセージ（要ログイン）
 
 ```typescript
 // 受信箱を取得
-const inboxResult = await client.pm.inbox();
-if (inboxResult.isOk()) {
-  for (const message of inboxResult.value) {
-    console.log(`From: ${message.sender.name}, Subject: ${message.subject}`);
-  }
+const inboxResult = await client.privateMessage.inbox();
+if (!inboxResult.isOk()) {
+  throw new Error('受信箱の取得に失敗しました');
+}
+for (const message of inboxResult.value) {
+  console.log(`From: ${message.sender.name}, Subject: ${message.subject}`);
 }
 
 // メッセージを送信
-await client.pm.send(recipientUser, '件名', '本文');
+await client.privateMessage.send(recipientUser, '件名', '本文');
 
 // メッセージを検索
-const searchResult = await client.pm.search('検索クエリ', 'all');
+const searchResult = await client.privateMessage.search('検索クエリ', 'all');
 ```
 
 ## エラーハンドリング

--- a/llms.txt
+++ b/llms.txt
@@ -1,10 +1,23 @@
-# wikidot-ts
+# @ukwhatn/wikidot
 
 > TypeScriptでWikidotサイトと対話するための非同期ユーティリティライブラリ
 
 ## 概要
 
-wikidot-tsは、Wikidot APIを操作するTypeScriptライブラリ。ページ取得・編集、フォーラム操作、プライベートメッセージ、ユーザー情報取得などWikidotの主要機能をサポート。
+@ukwhatn/wikidotは、Wikidot APIを操作するTypeScriptライブラリ。ページ取得・編集、フォーラム操作、プライベートメッセージ、ユーザー情報取得などWikidotの主要機能をサポート。
+
+## 重要: Result型
+
+このライブラリはneverthrowのResult型を使用。すべての非同期メソッドは`WikidotResultAsync<T>`を返す。
+
+```typescript
+// 正しい使用法
+const clientResult = await Client.create();
+if (!clientResult.isOk()) {
+  throw new Error('失敗');
+}
+const client = clientResult.value;  // ここでClient型が得られる
+```
 
 ## 主要コンポーネント
 
@@ -13,12 +26,19 @@ wikidot-tsは、Wikidot APIを操作するTypeScriptライブラリ。ページ�
 メインエントリポイント。認証とアクセサへのアクセスを提供。
 
 ```typescript
-const client = await Client.create();  // 未認証
-const client = await Client.create({ username, password });  // 認証済み
+import { Client } from '@ukwhatn/wikidot';
 
-client.site  // SiteAccessor
-client.user  // UserAccessor
-client.pm    // PrivateMessageAccessor
+// 未認証クライアント
+const clientResult = await Client.create();
+const client = clientResult.value;
+
+// 認証済みクライアント
+const authResult = await Client.create({ username, password });
+const authClient = authResult.value;
+
+client.site            // SiteAccessor
+client.user            // UserAccessor
+client.privateMessage  // PrivateMessageAccessor
 ```
 
 ### Site
@@ -93,11 +113,11 @@ await post.delete();
 プライベートメッセージ操作。受信箱、送信箱、検索。
 
 ```typescript
-const inboxResult = await client.pm.inbox();
-const sentResult = await client.pm.sentBox();
-const searchResult = await client.pm.search('query', 'all');
+const inboxResult = await client.privateMessage.inbox();
+const sentResult = await client.privateMessage.sentBox();
+const searchResult = await client.privateMessage.search('query', 'all');
 
-await client.pm.send(user, '件名', '本文');
+await client.privateMessage.send(user, '件名', '本文');
 ```
 
 ## Result型
@@ -170,10 +190,10 @@ src/
 ### Client
 - `site.get(unixName)` - サイト取得
 - `user.get(username)` - ユーザー取得
-- `pm.inbox()` - 受信箱取得
-- `pm.sentBox()` - 送信箱取得
-- `pm.send(user, subject, body)` - メッセージ送信
-- `pm.search(query, searchType)` - メッセージ検索
+- `privateMessage.inbox()` - 受信箱取得
+- `privateMessage.sentBox()` - 送信箱取得
+- `privateMessage.send(user, subject, body)` - メッセージ送信
+- `privateMessage.search(query, searchType)` - メッセージ検索
 
 ### Site
 - `page.get(fullname)` - ページ取得

--- a/src/module/client/accessors/pm-accessor.ts
+++ b/src/module/client/accessors/pm-accessor.ts
@@ -10,6 +10,16 @@ import type { Client } from '../client';
 
 /**
  * プライベートメッセージ操作アクセサ
+ *
+ * @example
+ * ```typescript
+ * // 受信箱を取得
+ * const inboxResult = await client.privateMessage.inbox();
+ * if (!inboxResult.isOk()) {
+ *   throw new Error('受信箱の取得に失敗しました');
+ * }
+ * const inbox = inboxResult.value;
+ * ```
  */
 export class PrivateMessageAccessor {
   public readonly client: Client;
@@ -20,8 +30,9 @@ export class PrivateMessageAccessor {
 
   /**
    * メッセージIDからメッセージを取得する
+   *
    * @param id - メッセージID
-   * @returns メッセージオブジェクト
+   * @returns Result型でラップされたメッセージオブジェクト
    */
   get(id: number): WikidotResultAsync<PrivateMessage> {
     return PrivateMessage.fromId(this.client, id);

--- a/src/module/client/accessors/site-accessor.ts
+++ b/src/module/client/accessors/site-accessor.ts
@@ -14,8 +14,18 @@ export class SiteAccessor {
 
   /**
    * UNIX名からサイトを取得する
+   *
    * @param unixName - サイトのUNIX名（例: 'scp-jp'）
-   * @returns サイトオブジェクト
+   * @returns Result型でラップされたサイトオブジェクト
+   *
+   * @example
+   * ```typescript
+   * const siteResult = await client.site.get('scp-jp');
+   * if (!siteResult.isOk()) {
+   *   throw new Error('サイトの取得に失敗しました');
+   * }
+   * const site = siteResult.value;
+   * ```
    */
   get(unixName: string): WikidotResultAsync<Site> {
     return Site.fromUnixName(this.client, unixName);

--- a/src/module/client/accessors/user-accessor.ts
+++ b/src/module/client/accessors/user-accessor.ts
@@ -23,9 +23,19 @@ export class UserAccessor {
 
   /**
    * ユーザー名からユーザーを取得する
+   *
    * @param name - ユーザー名
    * @param options - 取得オプション
-   * @returns ユーザー（存在しない場合はnull、raiseWhenNotFoundがtrueの場合はエラー）
+   * @returns Result型でラップされたユーザー（存在しない場合はnull、raiseWhenNotFoundがtrueの場合はエラー）
+   *
+   * @example
+   * ```typescript
+   * const userResult = await client.user.get('username');
+   * if (!userResult.isOk()) {
+   *   throw new Error('ユーザーの取得に失敗しました');
+   * }
+   * const user = userResult.value;
+   * ```
    */
   get(name: string, options: GetUserOptions = {}): WikidotResultAsync<User | null> {
     const { raiseWhenNotFound = false } = options;

--- a/src/module/client/client.ts
+++ b/src/module/client/client.ts
@@ -88,8 +88,29 @@ export class Client {
 
   /**
    * クライアントを作成する
+   *
    * @param options - クライアントオプション
-   * @returns クライアントインスタンス
+   * @returns Result型でラップされたクライアントインスタンス
+   *
+   * @example
+   * ```typescript
+   * import { Client } from '@ukwhatn/wikidot';
+   *
+   * // クライアントを作成
+   * const clientResult = await Client.create({
+   *   username: 'your_username',
+   *   password: 'your_password',
+   * });
+   *
+   * // Result型なのでisOk()でチェック後、.valueで取得
+   * if (!clientResult.isOk()) {
+   *   throw new Error('クライアントの作成に失敗しました');
+   * }
+   * const client = clientResult.value;
+   *
+   * // これでclient.site等にアクセス可能
+   * const siteResult = await client.site.get('scp-jp');
+   * ```
    */
   static create(options: ClientOptions = {}): WikidotResultAsync<Client> {
     const { username, password, domain = 'wikidot.com', amcConfig = {} } = options;


### PR DESCRIPTION
## Summary

- README.mdのパッケージ名を`wikidot-ts`から`@ukwhatn/wikidot`に修正
- Result型の正しい使用方法（`isOk()` + `.value`）を全ドキュメントに明記
- `client.pm`を`client.privateMessage`に修正
- llms.txt、CLAUDE.mdのコード例を同様に更新
- JSDocにResult型の説明と使用例を追加

## Background

パッケージ名がREADME.mdでは`wikidot-ts`となっていたが、実際のnpmパッケージ名は`@ukwhatn/wikidot`であった。
また、`Client.create()`が`WikidotResultAsync<Client>`を返すため、`await`後に直接`client.site`にアクセスしても型推論が効かない問題があった。

## Test plan

- [ ] 型チェック通過確認
- [ ] lint通過確認