### PR TITLE
fix: 重複exportエラーを修正

### DIFF
--- a/bunup.config.ts
+++ b/bunup.config.ts
@@ -11,6 +11,7 @@ export default defineConfig([
     minify: false,
     sourcemap: true,
     target: 'node',
+    splitting: false,
   },
   {
     name: 'errors',

--- a/src/module/client/client.ts
+++ b/src/module/client/client.ts
@@ -8,7 +8,7 @@ import {
   wdOkAsync,
 } from '../../common/types';
 import { AMCClient, type AMCConfig, login, logout } from '../../connector';
-import type { User } from '../user/user';
+import { User } from '../user/user';
 import { PrivateMessageAccessor } from './accessors/pm-accessor';
 import { SiteAccessor } from './accessors/site-accessor';
 import { UserAccessor } from './accessors/user-accessor';
@@ -108,7 +108,6 @@ export class Client {
           }
 
           // ログイン中のユーザー情報を取得
-          const { User } = await import('../user/user');
           const userResult = await User.fromName(client, username);
           if (userResult.isOk() && userResult.value) {
             client._me = userResult.value;

--- a/src/module/page/page.ts
+++ b/src/module/page/page.ts
@@ -18,7 +18,7 @@ import type { Site } from '../site';
 import type { AbstractUser } from '../user';
 import { PageFileCollection } from './page-file';
 import { PageMetaCollection } from './page-meta';
-import { type PageRevision, PageRevisionCollection } from './page-revision';
+import { PageRevision, PageRevisionCollection } from './page-revision';
 import { PageSource } from './page-source';
 import { PageVote, PageVoteCollection } from './page-vote';
 import { DEFAULT_MODULE_BODY, DEFAULT_PER_PAGE, SearchPagesQuery } from './search-query';
@@ -734,7 +734,6 @@ export class PageCollection extends Array<Page> {
         }
 
         // リビジョンをパース
-        const { PageRevision } = await import('./page-revision');
         for (let i = 0; i < targetPages.length; i++) {
           const page = targetPages[i];
           const response = result.value[i];


### PR DESCRIPTION
## Summary

- ビルド後のdistファイルで`SyntaxError: Cannot export a duplicate name`エラーが発生する問題を修正

## Changes

- `PageRevision`: `type`インポートを通常インポートに変更、動的インポートを削除
- `User`: `type`インポートを通常インポートに変更、動的インポートを削除  
- bunup設定: `splitting: false`を追加（code splitting時の重複export生成を防止）

## Root Cause

動的インポート（`await import()`）と`type`インポートを同一モジュールに対して併用すると、bunupのcode splitting時に重複exportが生成されていた。

## Test plan

- [x] `bun run typecheck` - 型チェック通過
- [x] `bun run build` - ビルド成功
- [x] `bun test` - 全234テスト通過
- [x] ローカル環境でのインポートテスト - エラーなし