### PR TITLE
feat: ページ操作時にIDを自動取得する機能を追加

### DIFF
--- a/src/module/page/page.ts
+++ b/src/module/page/page.ts
@@ -216,7 +216,9 @@ export class Page {
     if (this._id === null) {
       const result = await PageCollection.acquirePageIds(this.site, [this]);
       if (result.isErr()) {
-        throw new UnexpectedError(`Failed to acquire page ID for ${operation}: ${result.error.message}`);
+        throw new UnexpectedError(
+          `Failed to acquire page ID for ${operation}: ${result.error.message}`
+        );
       }
     }
     if (this._id === null) {


### PR DESCRIPTION
## Summary

- `ensureId`メソッドを追加し、ページIDが未取得の場合は自動的に`acquirePageIds`を呼び出す
- 以下のメソッドで`ensureId`を使用するように変更:
  - `destroy()`
  - `edit()`
  - `rename()`
  - `commitTags()`
  - `setParent()`
  - `vote()`
  - `cancelVote()`
  - `getDiscussion()`
  - `getMetas()`
  - `setMeta()`
  - `deleteMeta()`
- Python版（wikidot.py）と同様の動作を実現

## Motivation

Python版では`id`プロパティのgetterでIDを自動取得する実装になっているが、TypeScript版では明示的に`acquirePageIds()`を呼び出す必要があった。これにより、ページ操作時にIDが未取得の場合エラーになる問題があった。

## Test plan

- 型チェック通過を確認