### PR TITLE
ci: Node.js バージョンマトリックスを追加

### DIFF
--- a/.github/workflows/check_code_quality.yml
+++ b/.github/workflows/check_code_quality.yml
@@ -40,8 +40,16 @@ jobs:
 
   test:
     runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        node-version: [20, 22, 24, 25]
     steps:
     - uses: actions/checkout@v6
+
+    - name: Setup Node.js ${{ matrix.node-version }}
+      uses: actions/setup-node@v4
+      with:
+        node-version: ${{ matrix.node-version }}
 
     - name: Setup Bun
       uses: oven-sh/setup-bun@v2
@@ -56,6 +64,7 @@ jobs:
 
     - name: Upload coverage report
       uses: actions/upload-artifact@v6
+      if: matrix.node-version == 22
       with:
         name: coverage-report
         path: coverage/

--- a/package.json
+++ b/package.json
@@ -58,7 +58,7 @@
   },
   "homepage": "https://github.com/ukwhatn/wikidot-ts#readme",
   "engines": {
-    "node": ">=18"
+    "node": ">=20"
   },
   "dependencies": {
     "cheerio": "^1.0.0",


### PR DESCRIPTION
## Summary

- テストジョブをNode.js 20, 22, 24, 25のマトリックスに変更
- Active LTS (22), Maintenance LTS (20), Current (24, 25) バージョンでの動作確認
- カバレッジレポートはNode.js 22でのみアップロード

## Test plan

- CIが各Node.jsバージョンで正常に実行されることを確認