### PR TITLE
docs: ドキュメント・JSDoc・コメントの英語化

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -1,73 +1,73 @@
-name: バグ報告
-description: バグや不具合を報告する
+name: Bug Report
+description: Report a bug or issue
 title: "[Bug]: "
 labels: ["bug"]
 body:
   - type: markdown
     attributes:
       value: |
-        バグ報告ありがとうございます。
-        以下の項目をできるだけ詳しく記入してください。
+        Thank you for reporting a bug.
+        Please fill in the following items as detailed as possible.
 
   - type: textarea
     id: description
     attributes:
-      label: 概要
-      description: バグの内容を簡潔に説明してください
-      placeholder: どのような問題が発生していますか？
+      label: Summary
+      description: Briefly describe the bug
+      placeholder: What problem are you experiencing?
     validations:
       required: true
 
   - type: textarea
     id: reproduction
     attributes:
-      label: 再現手順
-      description: バグを再現する手順を記載してください
+      label: Steps to Reproduce
+      description: Describe the steps to reproduce the bug
       placeholder: |
-        1. '...' を実行
-        2. '...' を呼び出し
-        3. エラーが発生
+        1. Run '...'
+        2. Call '...'
+        3. Error occurs
     validations:
       required: true
 
   - type: textarea
     id: expected
     attributes:
-      label: 期待される動作
-      description: 本来どのように動作すべきかを記載してください
+      label: Expected Behavior
+      description: Describe how it should work
     validations:
       required: true
 
   - type: textarea
     id: actual
     attributes:
-      label: 実際の動作
-      description: 実際にどのような動作になっているかを記載してください
+      label: Actual Behavior
+      description: Describe what actually happens
     validations:
       required: true
 
   - type: textarea
     id: environment
     attributes:
-      label: 環境情報
-      description: 問題が発生した環境を記載してください
+      label: Environment
+      description: Describe your environment
       placeholder: |
-        - wikidot-ts バージョン:
-        - Node.js バージョン:
+        - wikidot-ts version:
+        - Node.js version:
         - OS:
-        - 実行環境: (Node.js / Bun / Deno / ブラウザ)
+        - Runtime: (Node.js / Bun / Deno / Browser)
     validations:
       required: true
 
   - type: textarea
     id: logs
     attributes:
-      label: エラーログ・スタックトレース
-      description: エラーメッセージやスタックトレースがあれば貼り付けてください
+      label: Error Logs / Stack Trace
+      description: Paste any error messages or stack traces if available
       render: shell
 
   - type: textarea
     id: additional
     attributes:
-      label: 補足情報
-      description: その他、関連する情報があれば記載してください
+      label: Additional Information
+      description: Any other relevant information

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,5 +1,5 @@
 blank_issues_enabled: true
 contact_links:
-  - name: 質問・ディスカッション
+  - name: Questions / Discussions
     url: https://github.com/ukwhatn/wikidot-ts/discussions
-    about: バグ報告や機能要望以外の質問はこちらへ
+    about: For questions other than bug reports or feature requests

--- a/.github/ISSUE_TEMPLATE/feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yml
@@ -1,45 +1,45 @@
-name: 機能要望
-description: 新機能や改善の提案をする
+name: Feature Request
+description: Suggest a new feature or improvement
 title: "[Feature]: "
 labels: ["enhancement"]
 body:
   - type: markdown
     attributes:
       value: |
-        機能要望ありがとうございます。
-        以下の項目をできるだけ詳しく記入してください。
+        Thank you for your feature request.
+        Please fill in the following items as detailed as possible.
 
   - type: textarea
     id: problem
     attributes:
-      label: 背景・課題
-      description: どのような問題を解決したいですか？どのような場面で困っていますか？
-      placeholder: "例: 〇〇をしたいが、現在の実装では△△ができない"
+      label: Background / Problem
+      description: What problem are you trying to solve? What situation are you facing?
+      placeholder: "e.g.: I want to do X, but the current implementation doesn't support Y"
     validations:
       required: true
 
   - type: textarea
     id: solution
     attributes:
-      label: 提案する解決策
-      description: どのような機能や変更があれば解決できると考えますか？
+      label: Proposed Solution
+      description: What feature or change would solve this problem?
     validations:
       required: true
 
   - type: textarea
     id: alternatives
     attributes:
-      label: 代替案
-      description: 他に検討した解決策があれば記載してください
+      label: Alternatives Considered
+      description: Describe any alternative solutions you've considered
 
   - type: textarea
     id: usecase
     attributes:
-      label: ユースケース
-      description: この機能がどのように使われるか、具体例があれば記載してください
+      label: Use Case
+      description: Provide concrete examples of how this feature would be used
       placeholder: |
         ```typescript
-        // 使用例
+        // Usage example
         import { Client } from '@ukwhatn/wikidot';
         const client = new Client();
         // ...
@@ -48,5 +48,5 @@ body:
   - type: textarea
     id: additional
     attributes:
-      label: 補足情報
-      description: 参考リンクや関連するIssueなど、その他の情報があれば記載してください
+      label: Additional Information
+      description: Any reference links, related issues, or other information

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,47 +1,47 @@
-## 概要
+## Summary
 
-<!-- このPRの目的・背景を簡潔に説明してください -->
+<!-- Briefly explain the purpose and background of this PR -->
 
-## 関連Issue
+## Related Issue
 
-<!-- 関連するIssueがあればリンクしてください -->
-<!-- 例: resolves #123 / fixes #456 / closes #789 -->
+<!-- Link any related issues if applicable -->
+<!-- e.g.: resolves #123 / fixes #456 / closes #789 -->
 
-## 変更内容
+## Changes
 
-<!-- 具体的に何を変更したかを箇条書きで記載してください -->
+<!-- List the specific changes made in bullet points -->
 
 -
 
-## 変更の種類
+## Type of Change
 
-<!-- 該当するものにチェックを入れてください -->
+<!-- Check all that apply -->
 
-- [ ] バグ修正 (既存の機能を壊さない修正)
-- [ ] 新機能 (既存の機能を壊さない追加)
-- [ ] 破壊的変更 (既存の機能に影響を与える変更)
-- [ ] ドキュメント更新
-- [ ] リファクタリング
-- [ ] テスト追加・修正
-- [ ] CI/CD・ビルド関連
+- [ ] Bug fix (non-breaking fix for existing functionality)
+- [ ] New feature (non-breaking addition)
+- [ ] Breaking change (change that affects existing functionality)
+- [ ] Documentation update
+- [ ] Refactoring
+- [ ] Test addition/modification
+- [ ] CI/CD or build related
 
-## テスト
+## Testing
 
-<!-- テスト方法や結果を記載してください -->
+<!-- Describe how the changes were tested -->
 
-- [ ] `bun run format` パス
-- [ ] `bun run lint` パス
-- [ ] `bun run typecheck` パス
-- [ ] `bun test` パス
+- [ ] `bun run format` passed
+- [ ] `bun run lint` passed
+- [ ] `bun run typecheck` passed
+- [ ] `bun test` passed
 
-## チェックリスト
+## Checklist
 
-<!-- PRを出す前に確認してください -->
+<!-- Verify before submitting the PR -->
 
-- [ ] コードがプロジェクトのスタイルガイドに従っている
-- [ ] 必要に応じてドキュメントを更新した
-- [ ] 変更に対するテストを追加した（該当する場合）
+- [ ] Code follows the project's style guide
+- [ ] Documentation has been updated as needed
+- [ ] Tests have been added for the changes (if applicable)
 
-## 補足情報
+## Additional Information
 
-<!-- レビュワーへの伝達事項、スクリーンショット等があれば記載してください -->
+<!-- Any notes for reviewers, screenshots, etc. -->

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,119 +1,119 @@
-# CLAUDE.md - wikidot-ts プロジェクトガイド
+# CLAUDE.md - wikidot-ts Project Guide
 
-このドキュメントはAIエージェント向けのプロジェクトガイドです。
+This document is a project guide for AI agents.
 
-## プロジェクト概要
+## Project Overview
 
-**wikidot-ts** は、TypeScriptでWikidotサイトと対話するためのユーティリティライブラリです。wikidot.pyのTypeScript移植版。
+**wikidot-ts** is a utility library for interacting with Wikidot sites in TypeScript. It is a TypeScript port of wikidot.py.
 
-- **バージョン**: 4.0.x
-- **Node.js対応**: 18以上
-- **ライセンス**: MIT
-- **パッケージ名**: `@ukwhatn/wikidot`
+- **Version**: 4.0.x
+- **Node.js Support**: 18 or higher
+- **License**: MIT
+- **Package Name**: `@ukwhatn/wikidot`
 
-### 主な機能
+### Main Features
 
-- サイト情報の取得・管理
-- ページの作成、編集、削除、検索（ListPagesModule対応）
-- ユーザー情報の取得・検索
-- フォーラム（カテゴリ、スレッド、投稿）操作
-- プライベートメッセージの送受信
-- 認証機能（ログインなしでも公開情報はアクセス可能）
+- Site information retrieval and management
+- Page creation, editing, deletion, and search (ListPagesModule support)
+- User information retrieval and search
+- Forum operations (categories, threads, posts)
+- Private message sending and receiving
+- Authentication (public information accessible without login)
 
-## ディレクトリ構造
+## Directory Structure
 
 ```
 wikidot-ts/
 ├── src/
-│   ├── index.ts              # パッケージエントリポイント
-│   ├── common/               # 共通ユーティリティ
-│   │   ├── decorators.ts     # @loginRequired デコレータ
-│   │   ├── errors/           # カスタムエラー
-│   │   ├── logger.ts         # ロギング設定
-│   │   └── types/            # 共通型定義
-│   ├── connector/            # HTTP通信
+│   ├── index.ts              # Package entry point
+│   ├── common/               # Common utilities
+│   │   ├── decorators.ts     # @loginRequired decorator
+│   │   ├── errors/           # Custom errors
+│   │   ├── logger.ts         # Logging configuration
+│   │   └── types/            # Common type definitions
+│   ├── connector/            # HTTP communication
 │   │   ├── amc-client.ts     # AjaxModuleConnectorClient
-│   │   └── auth.ts           # 認証処理
-│   ├── module/               # コアモジュール
-│   │   ├── client/           # Client（メインエントリポイント）
-│   │   ├── site/             # Site（サイト管理）
-│   │   ├── page/             # Page（ページ操作）
-│   │   ├── user/             # User階層
-│   │   ├── forum/            # フォーラム関連
-│   │   ├── private-message/  # プライベートメッセージ
-│   │   └── types.ts          # モジュール共通型
-│   └── util/                 # ユーティリティ
-│       ├── quick-module.ts   # QuickModule検索
-│       ├── string.ts         # 文字列変換
-│       └── parser/           # HTMLパーサー
+│   │   └── auth.ts           # Authentication handling
+│   ├── module/               # Core modules
+│   │   ├── client/           # Client (main entry point)
+│   │   ├── site/             # Site (site management)
+│   │   ├── page/             # Page (page operations)
+│   │   ├── user/             # User hierarchy
+│   │   ├── forum/            # Forum related
+│   │   ├── private-message/  # Private messages
+│   │   └── types.ts          # Module common types
+│   └── util/                 # Utilities
+│       ├── quick-module.ts   # QuickModule search
+│       ├── string.ts         # String conversion
+│       └── parser/           # HTML parser
 ├── tests/
-│   ├── unit/                 # ユニットテスト
-│   ├── integration/          # 統合テスト
-│   ├── fixtures/             # テストフィクスチャ
-│   └── mocks/                # モック
-├── package.json              # プロジェクト設定
-├── tsconfig.json             # TypeScript設定
-└── biome.json                # Biome設定
+│   ├── unit/                 # Unit tests
+│   ├── integration/          # Integration tests
+│   ├── fixtures/             # Test fixtures
+│   └── mocks/                # Mocks
+├── package.json              # Project configuration
+├── tsconfig.json             # TypeScript configuration
+└── biome.json                # Biome configuration
 ```
 
-## 開発コマンド
+## Development Commands
 
 ```bash
-# 依存関係インストール
+# Install dependencies
 bun install
 
-# フォーマット
+# Format
 bun run format
 
-# リント
+# Lint
 bun run lint
 
-# リント修正
+# Fix lint issues
 bun run lint:fix
 
-# 型チェック
+# Type check
 bun run typecheck
 
-# テスト実行
-bun test              # 全テスト
-bun test:cov          # カバレッジ付き
+# Run tests
+bun test              # All tests
+bun test:cov          # With coverage
 
-# ビルド
+# Build
 bun run build
 ```
 
-## アーキテクチャ
+## Architecture
 
-### 設計パターン
+### Design Patterns
 
-1. **Facadeパターン**: `Client`が複数システムの統一インターフェース
-2. **Accessorパターン**: 機能をグループ化（`client.user`, `client.site`, `site.page`等）
-3. **Collectionパターン**: 複数リソースの一括操作（`PageCollection`, `UserCollection`等）
-4. **Factoryパターン**: `Page.fromName()`, `Site.fromUnixName()`等の静的メソッド
+1. **Facade Pattern**: `Client` provides a unified interface to multiple systems
+2. **Accessor Pattern**: Groups functionality (`client.user`, `client.site`, `site.page`, etc.)
+3. **Collection Pattern**: Bulk operations on multiple resources (`PageCollection`, `UserCollection`, etc.)
+4. **Factory Pattern**: Static methods like `Page.fromName()`, `Site.fromUnixName()`
 
-### コアクラス
+### Core Classes
 
-すべての非同期メソッドは`WikidotResultAsync<T>`を返す。`isOk()`でチェック後、`.value`で値を取得する。
+All async methods return `WikidotResultAsync<T>`. Check with `isOk()`, then access the value with `.value`.
 
 ```typescript
 import { Client } from '@ukwhatn/wikidot';
 
-// Client - メインエントリポイント
+// Client - Main entry point
 const clientResult = await Client.create({ username, password });
 if (!clientResult.isOk()) throw new Error('Failed');
 const client = clientResult.value;
 
-// Site - サイト操作
+// Site - Site operations
 const siteResult = await client.site.get("scp-jp");
 if (!siteResult.isOk()) throw new Error('Failed');
 const site = siteResult.value;
 
-// ページ検索
+// Page search
 const pagesResult = await site.pages.search({ category: "*", tags: ["tag1"] });
 if (!pagesResult.isOk()) throw new Error('Failed');
 const pages = pagesResult.value;
 
-// Page - ページ操作
+// Page - Page operations
 const pageResult = await site.page.get("page-name");
 if (!pageResult.isOk()) throw new Error('Failed');
 const page = pageResult.value;
@@ -121,30 +121,30 @@ await page.getSource();
 await page.getVotes();
 ```
 
-### User階層
+### User Hierarchy
 
 ```
-AbstractUser (基底)
-├── User            # 通常ユーザー
-├── DeletedUser     # 削除済みユーザー
-├── AnonymousUser   # 匿名ユーザー
-├── GuestUser       # ゲストユーザー
-└── WikidotUser     # Wikidot公式ユーザー
+AbstractUser (base)
+├── User            # Regular user
+├── DeletedUser     # Deleted user
+├── AnonymousUser   # Anonymous user
+├── GuestUser       # Guest user
+└── WikidotUser     # Wikidot system user
 ```
 
-### エラーハンドリング
+### Error Handling
 
-neverthrowライブラリを使用したResult型でエラーを扱う:
+Errors are handled using Result type from the neverthrow library:
 
 ```typescript
 type WikidotResult<T, E = WikidotError> = Result<T, E>;
 type WikidotResultAsync<T, E = WikidotError> = ResultAsync<T, E>;
 ```
 
-### 例外階層
+### Error Hierarchy
 
 ```
-WikidotError (基底)
+WikidotError (base)
 ├── UnexpectedError
 ├── SessionCreateError
 ├── LoginRequiredError
@@ -159,14 +159,14 @@ WikidotError (基底)
 └── NoElementError
 ```
 
-## コード品質設定
+## Code Quality Configuration
 
-### Biome（リンター/フォーマッター）
+### Biome (Linter/Formatter)
 
-- 行長: 120文字
-- インデント: タブ（幅2）
-- セミコロン: 必須
-- クォート: ダブル
+- Line length: 120 characters
+- Indent: Tabs (width 2)
+- Semicolons: Required
+- Quotes: Double
 
 ### TypeScript
 
@@ -176,26 +176,26 @@ WikidotError (基底)
 
 ### Bun Test
 
-- カバレッジ要件: 80%以上目標
+- Coverage target: 80% or higher
 
-## 重要な実装詳細
+## Important Implementation Details
 
-### 認証フロー
+### Authentication Flow
 
-1. `Client.create({ username, password })` でクライアント作成
-2. 内部で`login()` → Wikidot ログインエンドポイントへPOST
-3. `WIKIDOT_SESSION_ID` クッキーを抽出
-4. `@loginRequired` デコレータで検証
+1. Create client with `Client.create({ username, password })`
+2. Internally calls `login()` -> POSTs to Wikidot login endpoint
+3. Extracts `WIKIDOT_SESSION_ID` cookie
+4. Validated by `@loginRequired` decorator
 
-### HTMLパース
+### HTML Parsing
 
-- cheerioライブラリ使用
-- `odateParse()`: Wikidot日時要素をDateに変換
-- `userParse()`: HTML要素からUser型を自動判定
+- Uses cheerio library
+- `odateParse()`: Converts Wikidot datetime elements to Date
+- `userParse()`: Automatically determines User type from HTML elements
 
 ### SearchPagesQuery
 
-ListPagesModuleの複雑なクエリをTypeScriptで表現:
+Expresses complex ListPagesModule queries in TypeScript:
 
 ```typescript
 interface SearchPagesQuery {
@@ -211,37 +211,37 @@ interface SearchPagesQuery {
 }
 ```
 
-## 環境変数
+## Environment Variables
 
 ```bash
 WIKIDOT_USERNAME=your_username
 WIKIDOT_PASSWORD=your_password
 ```
 
-## 依存関係
+## Dependencies
 
-### 必須
+### Required
 
-- `cheerio` - HTMLパース
-- `ky` - HTTPクライアント
-- `neverthrow` - Result型
-- `p-limit` - 並行数制限
-- `zod` - スキーマバリデーション
+- `cheerio` - HTML parsing
+- `ky` - HTTP client
+- `neverthrow` - Result type
+- `p-limit` - Concurrency limiting
+- `zod` - Schema validation
 
-### 開発
+### Development
 
-- `@biomejs/biome` - リンター/フォーマッター
-- `typescript` - 型チェック
-- `bunup` - バンドラー
+- `@biomejs/biome` - Linter/formatter
+- `typescript` - Type checking
+- `bunup` - Bundler
 
 ## CI/CD
 
 ### GitHub Actions
 
-- **check_code_quality.yml**: PR時にformat→lint→typecheck→test
-- **publish.yml**: リリース時にnpmへ公開
+- **check_code_quality.yml**: On PR: format -> lint -> typecheck -> test
+- **publish.yml**: On release: publish to npm
 
-## サブエージェント呼び出し時の追加情報
+## Additional Information for Subagent Calls
 
 ### quality-checker / lint-runner / format-runner / typecheck-runner / test-runner
 
@@ -255,20 +255,20 @@ test: bun test
 ### self-reviewer / pr-reviewer
 
 ```
-ベースブランチ: main
-アーキテクチャルール:
-  - Facadeパターン（Client）
-  - Accessorパターン
-  - Result型によるエラーハンドリング
-追加チェック:
-  - neverthrow Result型の適切な使用
-  - 循環依存の回避（types.tsのRef型活用）
+Base branch: main
+Architecture rules:
+  - Facade pattern (Client)
+  - Accessor pattern
+  - Result-based error handling
+Additional checks:
+  - Proper use of neverthrow Result type
+  - Avoid circular dependencies (use Ref types in types.ts)
 ```
 
-## 注意事項
+## Notes
 
-- TypeScript strictモードを維持
-- 循環依存を避けるため、`module/types.ts`のRef型インターフェースを活用
-- エラーは`neverthrow`のResult型で返却（例外throwは避ける）
-- 公開APIはAccessorパターンで構成
-- Python版（wikidot.py）との互換性を意識
+- Maintain TypeScript strict mode
+- Use Ref type interfaces in `module/types.ts` to avoid circular dependencies
+- Return errors using `neverthrow` Result type (avoid throwing exceptions)
+- Public APIs should follow the Accessor pattern
+- Maintain compatibility with Python version (wikidot.py)

--- a/README.md
+++ b/README.md
@@ -1,187 +1,187 @@
 # wikidot-ts
 
-TypeScriptでWikidotサイトと対話するための非同期ユーティリティライブラリ。
+An async utility library for interacting with Wikidot sites in TypeScript.
 
-## 概要
+## Overview
 
-wikidot-tsは、Wikidot APIを操作するためのTypeScriptライブラリです。ページの取得・編集、フォーラム操作、プライベートメッセージ、ユーザー情報の取得など、Wikidotの主要機能をサポートしています。
+wikidot-ts is a TypeScript library for working with the Wikidot API. It supports major Wikidot features including page retrieval and editing, forum operations, private messages, and user information retrieval.
 
-## 特徴
+## Features
 
-- 型安全なAPI（TypeScript完全対応）
-- Result型によるエラーハンドリング（neverthrow使用）
-- 非同期処理の完全サポート
-- ページ、フォーラム、プライベートメッセージなど主要機能をカバー
-- wikidot.pyとの高い互換性
+- Type-safe API (full TypeScript support)
+- Result-based error handling (using neverthrow)
+- Full async/await support
+- Covers major features: pages, forums, private messages, and more
+- High compatibility with wikidot.py
 
-## インストール
+## Installation
 
 ```bash
 bun add @ukwhatn/wikidot
 ```
 
-または
+or
 
 ```bash
 npm install @ukwhatn/wikidot
 ```
 
-## 基本的な使い方
+## Basic Usage
 
-このライブラリは`neverthrow`のResult型を使用します。すべての非同期メソッドは`WikidotResultAsync<T>`を返し、`isOk()`で成功を確認後、`.value`で値を取得します。
+This library uses the Result type from `neverthrow`. All async methods return `WikidotResultAsync<T>`. Check success with `isOk()`, then access the value with `.value`.
 
-### クライアントの作成
+### Creating a Client
 
 ```typescript
 import { Client } from '@ukwhatn/wikidot';
 
-// ログインなしでアクセス（公開情報のみ）
+// Access without login (public information only)
 const clientResult = await Client.create();
 if (!clientResult.isOk()) {
-  throw new Error('クライアントの作成に失敗しました');
+  throw new Error('Failed to create client');
 }
 const client = clientResult.value;
 
-// ログインしてアクセス
+// Access with login
 const authClientResult = await Client.create({
   username: 'your_username',
   password: 'your_password',
 });
 if (!authClientResult.isOk()) {
-  throw new Error('ログインに失敗しました');
+  throw new Error('Login failed');
 }
 const authClient = authClientResult.value;
 ```
 
-### サイトの取得
+### Retrieving a Site
 
 ```typescript
-// サイトを取得
+// Get a site
 const siteResult = await client.site.get('scp-jp');
 if (!siteResult.isOk()) {
-  throw new Error('サイトの取得に失敗しました');
+  throw new Error('Failed to retrieve site');
 }
 const site = siteResult.value;
-console.log(`サイト: ${site.title}`);
+console.log(`Site: ${site.title}`);
 ```
 
-### ページの操作
+### Page Operations
 
 ```typescript
-// ページを検索
+// Search pages
 const pagesResult = await site.pages.search({ category: 'scp', tags: ['safe'] });
 if (!pagesResult.isOk()) {
-  throw new Error('ページの検索に失敗しました');
+  throw new Error('Failed to search pages');
 }
 for (const page of pagesResult.value) {
   console.log(`${page.fullname}: ${page.title}`);
 }
 
-// 単一ページを取得
+// Get a single page
 const pageResult = await site.page.get('scp-001');
 if (!pageResult.isOk()) {
-  throw new Error('ページの取得に失敗しました');
+  throw new Error('Failed to retrieve page');
 }
 const page = pageResult.value;
-console.log(`タイトル: ${page.title}`);
-console.log(`レーティング: ${page.rating}`);
+console.log(`Title: ${page.title}`);
+console.log(`Rating: ${page.rating}`);
 ```
 
-### フォーラムの操作
+### Forum Operations
 
 ```typescript
-// フォーラムカテゴリを取得
+// Get forum categories
 const categoriesResult = await site.forum.getCategories();
 if (!categoriesResult.isOk()) {
-  throw new Error('フォーラムカテゴリの取得に失敗しました');
+  throw new Error('Failed to retrieve forum categories');
 }
 for (const category of categoriesResult.value) {
-  console.log(`カテゴリ: ${category.title}`);
+  console.log(`Category: ${category.title}`);
 }
 
-// スレッドに返信（要ログイン）
+// Reply to a thread (requires login)
 const threadResult = await site.forum.getThread(12345);
 if (!threadResult.isOk()) {
-  throw new Error('スレッドの取得に失敗しました');
+  throw new Error('Failed to retrieve thread');
 }
 const thread = threadResult.value;
-await thread.reply('返信内容', 'Re: タイトル');
+await thread.reply('Reply content', 'Re: Title');
 ```
 
-### プライベートメッセージ（要ログイン）
+### Private Messages (requires login)
 
 ```typescript
-// 受信箱を取得
+// Get inbox
 const inboxResult = await client.privateMessage.inbox();
 if (!inboxResult.isOk()) {
-  throw new Error('受信箱の取得に失敗しました');
+  throw new Error('Failed to retrieve inbox');
 }
 for (const message of inboxResult.value) {
   console.log(`From: ${message.sender.name}, Subject: ${message.subject}`);
 }
 
-// メッセージを送信
-await client.privateMessage.send(recipientUser, '件名', '本文');
+// Send a message
+await client.privateMessage.send(recipientUser, 'Subject', 'Body');
 
-// メッセージを検索
-const searchResult = await client.privateMessage.search('検索クエリ', 'all');
+// Search messages
+const searchResult = await client.privateMessage.search('search query', 'all');
 ```
 
-## エラーハンドリング
+## Error Handling
 
-wikidot-tsは`neverthrow`ライブラリを使用したResult型でエラーを処理します。
+wikidot-ts handles errors using the Result type from the `neverthrow` library.
 
 ```typescript
 const result = await site.page.get('non-existent-page');
 
 if (result.isOk()) {
   const page = result.value;
-  // 成功時の処理
+  // Handle success
 } else {
   const error = result.error;
   if (error instanceof NotFoundException) {
-    console.log('ページが見つかりません');
+    console.log('Page not found');
   } else if (error instanceof ForbiddenError) {
-    console.log('アクセス権限がありません');
+    console.log('Access denied');
   }
 }
 ```
 
-## 主要なエラー型
+## Main Error Types
 
-| エラー | 説明 |
-|--------|------|
-| `LoginRequiredError` | ログインが必要な操作 |
-| `NotFoundException` | リソースが見つからない |
-| `ForbiddenError` | アクセス権限がない |
-| `TargetExistsError` | リソースが既に存在する |
-| `WikidotStatusError` | Wikidot APIエラー |
+| Error | Description |
+|-------|-------------|
+| `LoginRequiredError` | Operation requires login |
+| `NotFoundException` | Resource not found |
+| `ForbiddenError` | Access denied |
+| `TargetExistsError` | Resource already exists |
+| `WikidotStatusError` | Wikidot API error |
 
-## wikidot.pyとの差異
+## Differences from wikidot.py
 
-wikidot-tsはwikidot.pyからの移植ですが、TypeScriptの慣習に合わせていくつかの違いがあります。
+wikidot-ts is a port of wikidot.py, with some differences to follow TypeScript conventions.
 
-### プロパティ → メソッド変換
+### Property to Method Conversion
 
-Pythonの`@property`デコレータを使用したプロパティは、TypeScriptではgetterメソッドとして実装されています。
+Python properties using the `@property` decorator are implemented as getter methods in TypeScript.
 
 | Python (wikidot.py) | TypeScript (wikidot-ts) |
 |---------------------|------------------------|
 | `site.base_url` | `site.getBaseUrl()` |
 | `page.url` | `page.getUrl()` |
-| `user.avatar_url` | `user.avatarUrl` (読み取り専用プロパティ) |
+| `user.avatar_url` | `user.avatarUrl` (readonly property) |
 
-### 命名規則
+### Naming Conventions
 
-- スネークケース → キャメルケース
-  - `page.fullname` (変更なし)
-  - `page.children_count` → `page.childrenCount`
-  - `page.created_by` → `page.createdBy`
+- snake_case to camelCase
+  - `page.fullname` (unchanged)
+  - `page.children_count` to `page.childrenCount`
+  - `page.created_by` to `page.createdBy`
 
-### エラーハンドリング
+### Error Handling
 
-- Python: 例外をスロー
-- TypeScript: `Result`型を返却（`neverthrow`使用）
+- Python: Throws exceptions
+- TypeScript: Returns `Result` type (using `neverthrow`)
 
 ```python
 # Python
@@ -201,49 +201,49 @@ if (result.isErr()) {
 }
 ```
 
-### オプション引数
+### Optional Arguments
 
-一部のメソッドでは、Python版と同様のオプション引数をサポートしています。
+Some methods support optional arguments similar to the Python version.
 
 ```typescript
-// raiseWhenNotFound オプション
+// raiseWhenNotFound option
 const user = await client.user.get("username", { raiseWhenNotFound: true });
 
-// returnExceptions オプション（AMCClient）
+// returnExceptions option (AMCClient)
 const results = await client.amcClient.requestWithOptions(bodies, { returnExceptions: true });
 ```
 
-## 開発
+## Development
 
-### セットアップ
+### Setup
 
 ```bash
 bun install
 ```
 
-### コマンド
+### Commands
 
 ```bash
-# 型チェック
+# Type check
 bun run typecheck
 
 # Lint
 bun run lint
 
-# フォーマット
+# Format
 bun run format
 
-# テスト
+# Test
 bun test
 
-# ビルド
+# Build
 bun run build
 ```
 
-## ライセンス
+## License
 
 MIT
 
-## 関連プロジェクト
+## Related Projects
 
-- [wikidot.py](https://github.com/ukwhatn/wikidot.py) - Python版のWikidotライブラリ
+- [wikidot.py](https://github.com/ukwhatn/wikidot.py) - Python version of the Wikidot library

--- a/llms.txt
+++ b/llms.txt
@@ -1,38 +1,38 @@
 # @ukwhatn/wikidot
 
-> TypeScriptでWikidotサイトと対話するための非同期ユーティリティライブラリ
+> An async utility library for interacting with Wikidot sites in TypeScript
 
-## 概要
+## Overview
 
-@ukwhatn/wikidotは、Wikidot APIを操作するTypeScriptライブラリ。ページ取得・編集、フォーラム操作、プライベートメッセージ、ユーザー情報取得などWikidotの主要機能をサポート。
+@ukwhatn/wikidot is a TypeScript library for working with the Wikidot API. It supports major Wikidot features including page retrieval and editing, forum operations, private messages, and user information retrieval.
 
-## 重要: Result型
+## Important: Result Type
 
-このライブラリはneverthrowのResult型を使用。すべての非同期メソッドは`WikidotResultAsync<T>`を返す。
+This library uses the Result type from neverthrow. All async methods return `WikidotResultAsync<T>`.
 
 ```typescript
-// 正しい使用法
+// Correct usage
 const clientResult = await Client.create();
 if (!clientResult.isOk()) {
-  throw new Error('失敗');
+  throw new Error('Failed');
 }
-const client = clientResult.value;  // ここでClient型が得られる
+const client = clientResult.value;  // Client type is obtained here
 ```
 
-## 主要コンポーネント
+## Main Components
 
 ### Client
 
-メインエントリポイント。認証とアクセサへのアクセスを提供。
+Main entry point. Provides authentication and accessor access.
 
 ```typescript
 import { Client } from '@ukwhatn/wikidot';
 
-// 未認証クライアント
+// Unauthenticated client
 const clientResult = await Client.create();
 const client = clientResult.value;
 
-// 認証済みクライアント
+// Authenticated client
 const authResult = await Client.create({ username, password });
 const authClient = authResult.value;
 
@@ -43,7 +43,7 @@ client.privateMessage  // PrivateMessageAccessor
 
 ### Site
 
-サイト操作。ページ、フォーラム、メンバーへのアクセス。
+Site operations. Access to pages, forums, and members.
 
 ```typescript
 const siteResult = await client.site.get('scp-jp');
@@ -57,17 +57,17 @@ site.member // MemberAccessor
 
 ### Page
 
-ページ操作。編集、削除、投票、ファイル、リビジョン。
+Page operations. Edit, delete, vote, files, and revisions.
 
 ```typescript
 const pageResult = await site.page.get('scp-001');
 const page = pageResult.value;
 
-page.title      // ページタイトル
-page.rating     // レーティング
-page.tags       // タグ配列
-page.createdBy  // 作成者
-page.createdAt  // 作成日時
+page.title      // Page title
+page.rating     // Rating
+page.tags       // Tags array
+page.createdBy  // Creator
+page.createdAt  // Creation date
 
 await page.edit({ source: 'new content' });
 await page.vote(1);
@@ -77,7 +77,7 @@ await page.getMetas();
 
 ### SearchPagesQuery
 
-ListPagesModuleのクエリ表現。
+Query expression for ListPagesModule.
 
 ```typescript
 const query = new SearchPagesQuery({
@@ -93,36 +93,36 @@ const pagesResult = await site.pages.search(query);
 
 ### ForumThread / ForumPost
 
-フォーラム操作。スレッド返信、投稿編集・削除。
+Forum operations. Thread replies, post editing and deletion.
 
 ```typescript
 const threadResult = await site.forum.getThread(12345);
 const thread = threadResult.value;
 
-await thread.reply('返信内容', 'タイトル');
-await thread.rename('新しいタイトル');
+await thread.reply('Reply content', 'Title');
+await thread.rename('New title');
 
 const postsResult = await thread.getPosts();
 const post = postsResult.value[0];
-await post.edit('新しい内容');
+await post.edit('New content');
 await post.delete();
 ```
 
 ### PrivateMessage
 
-プライベートメッセージ操作。受信箱、送信箱、検索。
+Private message operations. Inbox, sent box, and search.
 
 ```typescript
 const inboxResult = await client.privateMessage.inbox();
 const sentResult = await client.privateMessage.sentBox();
 const searchResult = await client.privateMessage.search('query', 'all');
 
-await client.privateMessage.send(user, '件名', '本文');
+await client.privateMessage.send(user, 'Subject', 'Body');
 ```
 
-## Result型
+## Result Type
 
-すべての非同期操作は`WikidotResultAsync<T>`を返す（neverthrowベース）。
+All async operations return `WikidotResultAsync<T>` (neverthrow-based).
 
 ```typescript
 const result = await site.page.get('page-name');
@@ -134,7 +134,7 @@ if (result.isOk()) {
 }
 ```
 
-## エラー階層
+## Error Hierarchy
 
 ```
 WikidotError
@@ -151,79 +151,79 @@ WikidotError
 └── NoElementError
 ```
 
-## User階層
+## User Hierarchy
 
 ```
 AbstractUser
-├── User           # 通常ユーザー
-├── DeletedUser    # 削除済み
-├── AnonymousUser  # 匿名（IP付き）
-├── GuestUser      # ゲスト
-└── WikidotUser    # システム
+├── User           # Regular user
+├── DeletedUser    # Deleted user
+├── AnonymousUser  # Anonymous (with IP)
+├── GuestUser      # Guest
+└── WikidotUser    # System user
 ```
 
-## ディレクトリ構造
+## Directory Structure
 
 ```
 src/
-├── common/           # 共通ユーティリティ
-│   ├── errors/       # エラー定義
-│   └── types.ts      # Result型定義
-├── connector/        # HTTP通信
+├── common/           # Common utilities
+│   ├── errors/       # Error definitions
+│   └── types.ts      # Result type definitions
+├── connector/        # HTTP communication
 │   ├── amc-client.ts # AjaxModuleConnector
-│   └── amc-config.ts # 設定
-├── module/           # コアモジュール
+│   └── amc-config.ts # Configuration
+├── module/           # Core modules
 │   ├── client/       # Client
 │   ├── site/         # Site
-│   ├── page/         # Page, PageRevision, PageFile等
+│   ├── page/         # Page, PageRevision, PageFile, etc.
 │   ├── forum/        # ForumCategory, ForumThread, ForumPost
 │   ├── private-message/ # PrivateMessage
-│   ├── user/         # User階層
-│   └── types.ts      # 共有インターフェース
-└── util/             # ユーティリティ
-    ├── parser/       # HTMLパーサー
+│   ├── user/         # User hierarchy
+│   └── types.ts      # Shared interfaces
+└── util/             # Utilities
+    ├── parser/       # HTML parser
     └── quick-module.ts # QuickModule API
 ```
 
-## 主要メソッド一覧
+## Main Methods List
 
 ### Client
-- `site.get(unixName)` - サイト取得
-- `user.get(username)` - ユーザー取得
-- `privateMessage.inbox()` - 受信箱取得
-- `privateMessage.sentBox()` - 送信箱取得
-- `privateMessage.send(user, subject, body)` - メッセージ送信
-- `privateMessage.search(query, searchType)` - メッセージ検索
+- `site.get(unixName)` - Get site
+- `user.get(username)` - Get user
+- `privateMessage.inbox()` - Get inbox
+- `privateMessage.sentBox()` - Get sent box
+- `privateMessage.send(user, subject, body)` - Send message
+- `privateMessage.search(query, searchType)` - Search messages
 
 ### Site
-- `page.get(fullname)` - ページ取得
-- `pages.search(query)` - ページ検索
-- `pages.all()` - 全ページ取得
-- `pages.getRecentChanges()` - 最近の変更
-- `forum.getCategories()` - カテゴリ一覧
-- `forum.getThread(id)` - スレッド取得
-- `member.getAll()` - メンバー一覧
-- `member.lookup(query)` - メンバー検索
+- `page.get(fullname)` - Get page
+- `pages.search(query)` - Search pages
+- `pages.all()` - Get all pages
+- `pages.getRecentChanges()` - Get recent changes
+- `forum.getCategories()` - Get category list
+- `forum.getThread(id)` - Get thread
+- `member.getAll()` - Get member list
+- `member.lookup(query)` - Search members
 
 ### Page
-- `edit(options)` - ページ編集
-- `destroy()` - ページ削除
-- `rename(newFullname)` - ページ名変更
-- `vote(value)` - 投票
-- `cancelVote()` - 投票キャンセル
-- `commitTags()` - タグ保存
-- `setParent(fullname)` - 親ページ設定
-- `getFiles()` - ファイル一覧
-- `getMetas()` - メタタグ取得
-- `setMeta(name, content)` - メタタグ設定
-- `deleteMeta(name)` - メタタグ削除
+- `edit(options)` - Edit page
+- `destroy()` - Delete page
+- `rename(newFullname)` - Rename page
+- `vote(value)` - Vote
+- `cancelVote()` - Cancel vote
+- `commitTags()` - Save tags
+- `setParent(fullname)` - Set parent page
+- `getFiles()` - Get file list
+- `getMetas()` - Get meta tags
+- `setMeta(name, content)` - Set meta tag
+- `deleteMeta(name)` - Delete meta tag
 
 ### ForumThread
-- `getPosts()` - 投稿一覧
-- `reply(source, title)` - 返信
-- `rename(newTitle)` - タイトル変更
+- `getPosts()` - Get post list
+- `reply(source, title)` - Reply
+- `rename(newTitle)` - Change title
 
 ### ForumPost
-- `getSource()` - ソース取得
-- `edit(source, title)` - 編集
-- `delete()` - 削除
+- `getSource()` - Get source
+- `edit(source, title)` - Edit
+- `delete()` - Delete

--- a/src/common/decorators.ts
+++ b/src/common/decorators.ts
@@ -1,12 +1,12 @@
 /**
- * デコレータユーティリティ
+ * Decorator utilities
  */
 
 import { LoginRequiredError } from './errors';
 import { fromPromise, type WikidotResultAsync, wdErrAsync } from './types';
 
 /**
- * クライアント参照を持つオブジェクトの型
+ * Type for objects that have a client reference
  */
 interface HasClient {
   client?: { requireLogin(): { isErr(): boolean; error?: Error } };
@@ -15,7 +15,7 @@ interface HasClient {
 }
 
 /**
- * オブジェクトからクライアント参照を取得する
+ * Get client reference from an object
  */
 function getClientRef(
   obj: HasClient
@@ -27,10 +27,10 @@ function getClientRef(
 }
 
 /**
- * ログイン必須メソッドデコレータ
+ * Login required method decorator
  *
- * このデコレータを適用したメソッドは、実行前にログイン状態をチェックする。
- * ログインしていない場合は LoginRequiredError を返す。
+ * Methods decorated with this will check login status before execution.
+ * Returns LoginRequiredError if not logged in.
  *
  * @example
  * class Page {

--- a/src/common/errors/amc.ts
+++ b/src/common/errors/amc.ts
@@ -1,21 +1,21 @@
 import { WikidotError } from './base';
 
 /**
- * Ajax Module Connector関連の基底エラー
+ * Base error for Ajax Module Connector related issues
  */
 export class AMCError extends WikidotError {}
 
 /**
- * HTTPステータスコードエラー
- * AMCへのリクエストがHTTPエラーで失敗した場合
+ * HTTP status code error
+ * Thrown when an AMC request fails with an HTTP error
  */
 export class AMCHttpError extends AMCError {
-  /** HTTPステータスコード */
+  /** HTTP status code */
   public readonly statusCode: number;
 
   /**
-   * @param message - エラーメッセージ
-   * @param statusCode - HTTPステータスコード
+   * @param message - Error message
+   * @param statusCode - HTTP status code
    */
   constructor(message: string, statusCode: number) {
     super(message);
@@ -24,16 +24,16 @@ export class AMCHttpError extends AMCError {
 }
 
 /**
- * Wikidotステータスコードエラー
- * AMCレスポンスのstatusがokでない場合
+ * Wikidot status code error
+ * Thrown when AMC response status is not ok
  */
 export class WikidotStatusError extends AMCError {
-  /** Wikidotステータスコード文字列 */
+  /** Wikidot status code string */
   public readonly statusCode: string;
 
   /**
-   * @param message - エラーメッセージ
-   * @param statusCode - ステータスコード（例: 'not_ok', 'try_again'）
+   * @param message - Error message
+   * @param statusCode - Status code (e.g., 'not_ok', 'try_again')
    */
   constructor(message: string, statusCode: string) {
     super(message);
@@ -42,7 +42,7 @@ export class WikidotStatusError extends AMCError {
 }
 
 /**
- * レスポンスデータエラー
- * レスポンスのパースに失敗した場合
+ * Response data error
+ * Thrown when response parsing fails
  */
 export class ResponseDataError extends AMCError {}

--- a/src/common/errors/base.ts
+++ b/src/common/errors/base.ts
@@ -1,13 +1,13 @@
 /**
- * Wikidotライブラリの基底エラークラス
- * 全てのカスタムエラーはこのクラスを継承する
+ * Base error class for the Wikidot library
+ * All custom errors inherit from this class
  */
 export abstract class WikidotError extends Error {
-  /** エラー名 */
+  /** Error name */
   public override readonly name: string;
 
   /**
-   * @param message - エラーメッセージ
+   * @param message - Error message
    */
   constructor(message: string) {
     super(message);
@@ -17,7 +17,7 @@ export abstract class WikidotError extends Error {
 }
 
 /**
- * 予期せぬエラー
- * 内部的な不整合やバグを表す
+ * Unexpected error
+ * Represents internal inconsistencies or bugs
  */
 export class UnexpectedError extends WikidotError {}

--- a/src/common/errors/session.ts
+++ b/src/common/errors/session.ts
@@ -1,19 +1,19 @@
 import { WikidotError } from './base';
 
 /**
- * セッション関連の基底エラー
+ * Base error for session related issues
  */
 export class SessionError extends WikidotError {}
 
 /**
- * セッション作成失敗エラー
- * ログイン試行が失敗した場合にスロー
+ * Session creation failure error
+ * Thrown when a login attempt fails
  */
 export class SessionCreateError extends SessionError {}
 
 /**
- * ログイン必須エラー
- * 認証が必要な操作を未ログイン状態で実行した場合にスロー
+ * Login required error
+ * Thrown when an authenticated operation is attempted without login
  */
 export class LoginRequiredError extends SessionError {
   constructor(message = 'Login is required for this operation') {

--- a/src/common/errors/target.ts
+++ b/src/common/errors/target.ts
@@ -1,31 +1,31 @@
 import { WikidotError } from './base';
 
 /**
- * リソース未発見エラー
- * 要求されたリソースが存在しない場合
+ * Resource not found error
+ * Thrown when the requested resource does not exist
  */
 export class NotFoundException extends WikidotError {}
 
 /**
- * リソース既存エラー
- * 作成しようとしたリソースが既に存在する場合
+ * Resource already exists error
+ * Thrown when attempting to create a resource that already exists
  */
 export class TargetExistsError extends WikidotError {}
 
 /**
- * ターゲット状態エラー
- * リソースが操作不可能な状態の場合（ロック中など）
+ * Target state error
+ * Thrown when a resource is in an inoperable state (e.g., locked)
  */
 export class TargetError extends WikidotError {}
 
 /**
- * アクセス拒否エラー
- * 権限不足で操作が拒否された場合
+ * Access denied error
+ * Thrown when an operation is denied due to insufficient permissions
  */
 export class ForbiddenError extends WikidotError {}
 
 /**
- * HTML要素未発見エラー
- * パース中に必要な要素が見つからない場合
+ * HTML element not found error
+ * Thrown when a required element is not found during parsing
  */
 export class NoElementError extends WikidotError {}

--- a/src/common/logger.ts
+++ b/src/common/logger.ts
@@ -1,17 +1,17 @@
 /**
- * ロギング機能を提供するモジュール
+ * Module providing logging functionality
  *
- * このモジュールは、ライブラリ全体で使用されるロガーを設定し、提供する。
- * デフォルトでは出力を行わず、アプリケーション側でのログ制御を可能にする。
+ * This module configures and provides loggers used throughout the library.
+ * By default, it does not output anything, allowing application-side log control.
  */
 
 /**
- * ログレベル
+ * Log level
  */
 export type LogLevel = 'debug' | 'info' | 'warn' | 'error';
 
 /**
- * ログレベルの優先度（数値が大きいほど重要）
+ * Log level priority (higher number = more important)
  */
 const LOG_LEVEL_PRIORITY: Record<LogLevel, number> = {
   debug: 0,
@@ -21,7 +21,7 @@ const LOG_LEVEL_PRIORITY: Record<LogLevel, number> = {
 };
 
 /**
- * ロガーハンドラー
+ * Logger handler
  */
 export type LogHandler = (
   level: LogLevel,
@@ -31,14 +31,14 @@ export type LogHandler = (
 ) => void;
 
 /**
- * NullHandler: 何も出力しない（デフォルト）
+ * NullHandler: Outputs nothing (default)
  */
 export const nullHandler: LogHandler = () => {
-  // 何もしない
+  // Do nothing
 };
 
 /**
- * ConsoleHandler: コンソールに出力する
+ * ConsoleHandler: Outputs to console
  */
 export const consoleHandler: LogHandler = (
   level: LogLevel,
@@ -66,7 +66,7 @@ export const consoleHandler: LogHandler = (
 };
 
 /**
- * ロガークラス
+ * Logger class
  */
 export class Logger {
   private readonly name: string;
@@ -80,28 +80,28 @@ export class Logger {
   }
 
   /**
-   * ハンドラーを設定
+   * Set handler
    */
   setHandler(handler: LogHandler): void {
     this.handler = handler;
   }
 
   /**
-   * ログレベルを設定
+   * Set log level
    */
   setLevel(level: LogLevel): void {
     this.level = level;
   }
 
   /**
-   * 指定レベルがログ出力対象かどうか
+   * Check if the specified level should be logged
    */
   private shouldLog(level: LogLevel): boolean {
     return LOG_LEVEL_PRIORITY[level] >= LOG_LEVEL_PRIORITY[this.level];
   }
 
   /**
-   * ログ出力
+   * Output log
    */
   private log(level: LogLevel, message: string, ...args: unknown[]): void {
     if (this.shouldLog(level)) {
@@ -127,18 +127,18 @@ export class Logger {
 }
 
 /**
- * ロガーを取得
- * @param name - ロガー名（デフォルト: "wikidot"）
- * @returns ロガーインスタンス
+ * Get logger
+ * @param name - Logger name (default: "wikidot")
+ * @returns Logger instance
  */
 export function getLogger(name = 'wikidot'): Logger {
   return new Logger(name);
 }
 
 /**
- * コンソール出力用ハンドラを設定
- * @param logger - 設定するロガー
- * @param level - ログレベル（デフォルト: "warn"）
+ * Setup console output handler
+ * @param logger - Logger to configure
+ * @param level - Log level (default: "warn")
  */
 export function setupConsoleHandler(logger: Logger, level: LogLevel = 'warn'): void {
   logger.setHandler(consoleHandler);
@@ -146,6 +146,6 @@ export function setupConsoleHandler(logger: Logger, level: LogLevel = 'warn'): v
 }
 
 /**
- * パッケージ全体で使用されるデフォルトロガー
+ * Default logger used throughout the package
  */
 export const logger: Logger = getLogger();

--- a/src/common/types/common.ts
+++ b/src/common/types/common.ts
@@ -1,11 +1,11 @@
-/** 日時型（ISO 8601形式） */
+/** DateTime type (ISO 8601 format) */
 export type DateTimeString = string;
 
-/** ユーザーIDまたはユーザー名 */
+/** User ID or username */
 export type UserIdentifier = number | string;
 
-/** サイトUNIX名 */
+/** Site UNIX name */
 export type SiteUnixName = string;
 
-/** ページフルネーム（カテゴリ:名前） */
+/** Page fullname (category:name) */
 export type PageFullname = string;

--- a/src/common/types/result.ts
+++ b/src/common/types/result.ts
@@ -1,31 +1,31 @@
 import { err, errAsync, ok, okAsync, type Result, ResultAsync } from 'neverthrow';
 import type { WikidotError } from '../errors';
 
-/** 同期Result型エイリアス */
+/** Synchronous Result type alias */
 export type WikidotResult<T> = Result<T, WikidotError>;
 
-/** 非同期Result型エイリアス */
+/** Asynchronous Result type alias */
 export type WikidotResultAsync<T> = ResultAsync<T, WikidotError>;
 
-/** 成功Resultを生成 */
+/** Create success Result */
 export const wdOk = <T>(value: T): WikidotResult<T> => ok(value);
 
-/** エラーResultを生成 */
+/** Create error Result */
 export const wdErr = <E extends WikidotError>(error: E): WikidotResult<never> => err(error);
 
-/** 成功ResultAsyncを生成 */
+/** Create success ResultAsync */
 export const wdOkAsync = <T>(value: T): WikidotResultAsync<T> => okAsync(value);
 
-/** エラーResultAsyncを生成 */
+/** Create error ResultAsync */
 export const wdErrAsync = <E extends WikidotError>(error: E): WikidotResultAsync<never> =>
   errAsync(error);
 
-/** Promiseからの変換 */
+/** Convert from Promise */
 export const fromPromise = <T>(
   promise: Promise<T>,
   errorMapper: (error: unknown) => WikidotError
 ): WikidotResultAsync<T> => ResultAsync.fromPromise(promise, errorMapper);
 
-/** 複数ResultAsyncの結合 */
+/** Combine multiple ResultAsync */
 export const combineResults = <T>(results: WikidotResultAsync<T>[]): WikidotResultAsync<T[]> =>
   ResultAsync.combine(results);

--- a/src/connector/amc-client.ts
+++ b/src/connector/amc-client.ts
@@ -259,10 +259,10 @@ export class AMCClient {
 
     while (true) {
       try {
-        // wikidot_token7を追加
+        // Add wikidot_token7
         const requestBody = { ...body, wikidot_token7: WIKIDOT_TOKEN7 };
 
-        // URLエンコードされたボディを作成
+        // Create URL-encoded body
         const formData = new URLSearchParams();
         for (const [key, value] of Object.entries(requestBody)) {
           if (value !== undefined) {
@@ -275,7 +275,7 @@ export class AMCClient {
           body: formData.toString(),
         });
 
-        // JSONとしてパース
+        // Parse as JSON
         let responseData: unknown;
         try {
           responseData = await response.json();
@@ -285,7 +285,7 @@ export class AMCClient {
           );
         }
 
-        // zodでバリデーション
+        // Validate with zod
         const parseResult = amcResponseSchema.safeParse(responseData);
         if (!parseResult.success) {
           return wdErrAsync(
@@ -295,7 +295,7 @@ export class AMCClient {
 
         const amcResponse = parseResult.data;
 
-        // try_againの場合はリトライ
+        // Retry if try_again
         if (amcResponse.status === 'try_again') {
           retryCount++;
           if (retryCount >= this.config.retryLimit) {
@@ -311,7 +311,7 @@ export class AMCClient {
           continue;
         }
 
-        // no_permissionの場合はForbiddenError
+        // ForbiddenError if no_permission
         if (amcResponse.status === 'no_permission') {
           const targetStr = body.moduleName
             ? `moduleName: ${body.moduleName}`
@@ -325,7 +325,7 @@ export class AMCClient {
           );
         }
 
-        // okでない場合はエラー
+        // Error if status is not ok
         if (amcResponse.status !== 'ok') {
           return wdErrAsync(
             new WikidotStatusError(
@@ -337,7 +337,7 @@ export class AMCClient {
 
         return wdOkAsync(amcResponse);
       } catch (error) {
-        // HTTPエラーの場合はリトライ
+        // Retry on HTTP error
         retryCount++;
         if (retryCount >= this.config.retryLimit) {
           const statusCode =

--- a/src/connector/amc-client.ts
+++ b/src/connector/amc-client.ts
@@ -20,9 +20,9 @@ import { AMCHeader } from './amc-header';
 import { type AMCRequestBody, type AMCResponse, amcResponseSchema } from './amc-types';
 
 /**
- * 機密情報をマスクする（ログ出力用）
- * @param body - マスク対象のリクエストボディ
- * @returns マスクされたボディ
+ * Mask sensitive information (for logging)
+ * @param body - Request body to mask
+ * @returns Masked body
  */
 export function maskSensitiveData(body: AMCRequestBody): Record<string, unknown> {
   const masked = { ...body };
@@ -36,12 +36,12 @@ export function maskSensitiveData(body: AMCRequestBody): Record<string, unknown>
 }
 
 /**
- * 指数バックオフ間隔を計算する（ジッター付き）
- * @param retryCount - 現在のリトライ回数（1から開始）
- * @param baseInterval - 基本間隔（ミリ秒）
- * @param backoffFactor - バックオフ係数
- * @param maxBackoff - 最大バックオフ間隔（ミリ秒）
- * @returns 計算されたバックオフ間隔（ミリ秒）
+ * Calculate exponential backoff interval (with jitter)
+ * @param retryCount - Current retry count (starts from 1)
+ * @param baseInterval - Base interval (milliseconds)
+ * @param backoffFactor - Backoff factor
+ * @param maxBackoff - Maximum backoff interval (milliseconds)
+ * @returns Calculated backoff interval (milliseconds)
  */
 function calculateBackoff(
   retryCount: number,
@@ -55,51 +55,51 @@ function calculateBackoff(
 }
 
 /**
- * 指定時間待機する
- * @param ms - 待機時間（ミリ秒）
+ * Sleep for specified duration
+ * @param ms - Duration in milliseconds
  */
 function sleep(ms: number): Promise<void> {
   return new Promise((resolve) => setTimeout(resolve, ms));
 }
 
 /**
- * AMCリクエストオプション
+ * AMC request options
  */
 export interface AMCRequestOptions {
-  /** サイト名（デフォルト: www） */
+  /** Site name (default: www) */
   siteName?: string;
-  /** SSL対応（省略時は自動検出） */
+  /** SSL support (auto-detected if omitted) */
   sslSupported?: boolean;
-  /** エラーを例外として投げずに結果に含める（デフォルト: false） */
+  /** Include errors in results instead of throwing (default: false) */
   returnExceptions?: boolean;
 }
 
 /**
- * Ajax Module Connectorクライアント
- * Wikidot AMCエンドポイントへのリクエストを管理する
+ * Ajax Module Connector client
+ * Manages requests to Wikidot AMC endpoint
  */
 export class AMCClient {
-  /** kyインスタンス */
+  /** ky instance */
   private readonly ky: KyInstance;
 
-  /** 並列リクエスト制限 */
+  /** Concurrent request limiter */
   private readonly limit: LimitFunction;
 
-  /** ヘッダー管理 */
+  /** Header manager */
   public readonly header: AMCHeader;
 
-  /** 設定 */
+  /** Configuration */
   public readonly config: AMCConfig;
 
-  /** ベースドメイン */
+  /** Base domain */
   public readonly domain: string;
 
-  /** SSL対応状況のキャッシュ */
+  /** SSL support status cache */
   private sslCache: Map<string, boolean> = new Map();
 
   /**
-   * @param config - AMC設定（省略時はデフォルト値）
-   * @param domain - ベースドメイン（デフォルト: wikidot.com）
+   * @param config - AMC configuration (uses defaults if omitted)
+   * @param domain - Base domain (default: wikidot.com)
    */
   constructor(config: Partial<AMCConfig> = {}, domain = 'wikidot.com') {
     this.config = { ...DEFAULT_AMC_CONFIG, ...config };
@@ -109,26 +109,26 @@ export class AMCClient {
 
     this.ky = ky.create({
       timeout: this.config.timeout,
-      retry: 0, // 手動でリトライを制御
+      retry: 0, // Manual retry control
     });
 
-    // wwwは常にSSL対応
+    // www always supports SSL
     this.sslCache.set('www', true);
   }
 
   /**
-   * サイトの存在とSSL対応状況を確認する
-   * @param siteName - サイト名
-   * @returns SSL対応状況（true: HTTPS、false: HTTP）
+   * Check site existence and SSL support status
+   * @param siteName - Site name
+   * @returns SSL support status (true: HTTPS, false: HTTP)
    */
   checkSiteSSL(siteName: string): WikidotResultAsync<boolean> {
-    // キャッシュに存在すればそれを返す
+    // Return cached value if exists
     const cached = this.sslCache.get(siteName);
     if (cached !== undefined) {
       return wdOkAsync(cached);
     }
 
-    // wwwは常にSSL対応
+    // www always supports SSL
     if (siteName === 'www') {
       return wdOkAsync(true);
     }
@@ -140,16 +140,16 @@ export class AMCClient {
           redirect: 'manual',
         });
 
-        // 404の場合はサイトが存在しない
+        // 404 means site does not exist
         if (response.status === 404) {
           throw new NotFoundException(`Site is not found: ${siteName}.${this.domain}`);
         }
 
-        // 301リダイレクトでhttpsに向かう場合はSSL対応
+        // SSL supported if 301 redirect to https
         const isSSL =
           response.status === 301 && response.headers.get('Location')?.startsWith('https') === true;
 
-        // キャッシュに保存
+        // Save to cache
         this.sslCache.set(siteName, isSSL);
         return isSSL;
       })(),
@@ -163,11 +163,11 @@ export class AMCClient {
   }
 
   /**
-   * AMCリクエストを実行する
-   * @param bodies - リクエストボディ配列
-   * @param siteName - サイト名（省略時はwww）
-   * @param sslSupported - SSL対応（省略時は自動検出）
-   * @returns レスポンス配列
+   * Execute AMC request
+   * @param bodies - Request body array
+   * @param siteName - Site name (default: www)
+   * @param sslSupported - SSL support (auto-detected if omitted)
+   * @returns Response array
    */
   request(
     bodies: AMCRequestBody[],
@@ -182,10 +182,10 @@ export class AMCClient {
   }
 
   /**
-   * AMCリクエストを実行する（オプション指定版）
-   * @param bodies - リクエストボディ配列
-   * @param options - リクエストオプション
-   * @returns レスポンス配列（returnExceptionsがtrueの場合はエラーも含む）
+   * Execute AMC request (with options)
+   * @param bodies - Request body array
+   * @param options - Request options
+   * @returns Response array (includes errors if returnExceptions is true)
    */
   requestWithOptions(
     bodies: AMCRequestBody[],
@@ -195,7 +195,7 @@ export class AMCClient {
 
     return fromPromise(
       (async () => {
-        // SSL対応状況を取得
+        // Get SSL support status
         let ssl = sslSupported;
         if (ssl === undefined) {
           const sslResult = await this.checkSiteSSL(siteName);
@@ -208,13 +208,13 @@ export class AMCClient {
         const protocol = ssl ? 'https' : 'http';
         const url = `${protocol}://${siteName}.${this.domain}/ajax-module-connector.php`;
 
-        // 並列でリクエストを実行
+        // Execute requests in parallel
         const results = await Promise.all(
           bodies.map((body) => this.limit(() => this.singleRequest(body, url)))
         );
 
         if (returnExceptions) {
-          // エラーも含めてすべての結果を返す
+          // Return all results including errors
           return results.map((r) => {
             if (r.isOk()) {
               return r.value;
@@ -223,7 +223,7 @@ export class AMCClient {
           });
         }
 
-        // エラーがあれば最初のエラーをスロー
+        // Throw first error if any
         const firstError = results.find((r) => r.isErr());
         if (firstError?.isErr()) {
           throw firstError.error;
@@ -246,10 +246,10 @@ export class AMCClient {
   }
 
   /**
-   * 単一リクエストを実行する内部メソッド
-   * @param body - リクエストボディ
-   * @param url - リクエストURL
-   * @returns レスポンス
+   * Internal method to execute a single request
+   * @param body - Request body
+   * @param url - Request URL
+   * @returns Response
    */
   private async singleRequest(
     body: AMCRequestBody,

--- a/src/connector/amc-config.ts
+++ b/src/connector/amc-config.ts
@@ -1,27 +1,27 @@
 /**
- * Ajax Module Connector設定
+ * Ajax Module Connector configuration
  */
 export interface AMCConfig {
-  /** リクエストタイムアウト（ミリ秒） */
+  /** Request timeout (milliseconds) */
   timeout: number;
 
-  /** リトライ上限回数 */
+  /** Maximum retry count */
   retryLimit: number;
 
-  /** リトライ基本間隔（ミリ秒） */
+  /** Base retry interval (milliseconds) */
   retryInterval: number;
 
-  /** 最大バックオフ（ミリ秒） */
+  /** Maximum backoff (milliseconds) */
   maxBackoff: number;
 
-  /** バックオフ係数 */
+  /** Backoff factor */
   backoffFactor: number;
 
-  /** 最大並列リクエスト数 */
+  /** Maximum concurrent requests */
   semaphoreLimit: number;
 }
 
-/** デフォルトAMC設定 */
+/** Default AMC configuration */
 export const DEFAULT_AMC_CONFIG: AMCConfig = {
   timeout: 20000,
   retryLimit: 5,
@@ -32,14 +32,14 @@ export const DEFAULT_AMC_CONFIG: AMCConfig = {
 };
 
 /**
- * Wikidotが要求する固定トークン値
- * これはWikidotのフロントエンドから取得される固定値で、
- * セキュリティトークンではなく単なる識別子として使用される
+ * Fixed token value required by Wikidot
+ * This is a fixed value obtained from Wikidot's frontend,
+ * used as an identifier rather than a security token
  */
 export const WIKIDOT_TOKEN7 = '123456';
 
 /**
- * HTTPエラー時のフォールバックステータスコード
- * レスポンスからステータスコードを取得できない場合に使用
+ * Fallback HTTP status code for HTTP errors
+ * Used when status code cannot be retrieved from response
  */
 export const DEFAULT_HTTP_STATUS_CODE = 999;

--- a/src/connector/amc-header.ts
+++ b/src/connector/amc-header.ts
@@ -1,5 +1,5 @@
 /**
- * AMCリクエストヘッダーを管理するクラス
+ * Class for managing AMC request headers
  */
 export class AMCHeader {
   private cookies: Map<string, string>;
@@ -8,7 +8,7 @@ export class AMCHeader {
   private referer: string;
 
   /**
-   * @param options - ヘッダー初期化オプション
+   * @param options - Header initialization options
    */
   constructor(options?: { contentType?: string; userAgent?: string; referer?: string }) {
     this.contentType = options?.contentType ?? 'application/x-www-form-urlencoded; charset=UTF-8';
@@ -18,34 +18,34 @@ export class AMCHeader {
   }
 
   /**
-   * Cookieを設定する
-   * @param name - Cookie名
-   * @param value - Cookie値
+   * Set a cookie
+   * @param name - Cookie name
+   * @param value - Cookie value
    */
   setCookie(name: string, value: string): void {
     this.cookies.set(name, value);
   }
 
   /**
-   * Cookieを削除する
-   * @param name - Cookie名
+   * Delete a cookie
+   * @param name - Cookie name
    */
   deleteCookie(name: string): void {
     this.cookies.delete(name);
   }
 
   /**
-   * Cookieを取得する
-   * @param name - Cookie名
-   * @returns Cookie値、存在しない場合はundefined
+   * Get a cookie
+   * @param name - Cookie name
+   * @returns Cookie value, undefined if not exists
    */
   getCookie(name: string): string | undefined {
     return this.cookies.get(name);
   }
 
   /**
-   * HTTPヘッダーオブジェクトを取得する
-   * @returns ヘッダー辞書
+   * Get HTTP headers object
+   * @returns Headers dictionary
    */
   getHeaders(): Record<string, string> {
     const cookieString = Array.from(this.cookies.entries())

--- a/src/connector/amc-types.ts
+++ b/src/connector/amc-types.ts
@@ -1,7 +1,7 @@
 import { z } from 'zod';
 
 /**
- * AMCリクエストボディの値型
+ * AMC request body value type
  */
 export type AMCRequestBodyValue =
   | string
@@ -13,7 +13,7 @@ export type AMCRequestBodyValue =
   | AMCRequestBodyValue[];
 
 /**
- * AMCリクエストボディの型定義
+ * AMC request body type definition
  */
 export interface AMCRequestBody {
   moduleName?: string;
@@ -23,7 +23,7 @@ export interface AMCRequestBody {
 }
 
 /**
- * AMCレスポンスのベーススキーマ
+ * AMC response base schema
  */
 const baseSchema: z.ZodObject<{
   status: z.ZodString;
@@ -36,18 +36,18 @@ const baseSchema: z.ZodObject<{
 });
 
 /**
- * AMCレスポンススキーマ
+ * AMC response schema
  */
 export const amcResponseSchema: z.ZodType<z.infer<typeof baseSchema> & Record<string, unknown>> =
   baseSchema.passthrough();
 
 /**
- * AMCレスポンス型
+ * AMC response type
  */
 export type AMCResponse = z.infer<typeof amcResponseSchema>;
 
 /**
- * 成功したAMCレスポンス
+ * Successful AMC response
  */
 export interface AMCSuccessResponse {
   status: 'ok';
@@ -56,9 +56,9 @@ export interface AMCSuccessResponse {
 }
 
 /**
- * AMCレスポンスが成功かどうかを判定する型ガード
- * @param response - AMCレスポンス
- * @returns 成功レスポンスの場合true
+ * Type guard to check if AMC response is successful
+ * @param response - AMC response
+ * @returns true if response is successful
  */
 export function isSuccessResponse(response: AMCResponse): response is AMCSuccessResponse {
   return response.status === 'ok';

--- a/src/connector/auth.ts
+++ b/src/connector/auth.ts
@@ -5,11 +5,11 @@ import type { AuthClientContext } from '../module/types';
 const LOGIN_URL = 'https://www.wikidot.com/default--flow/login__LoginPopupScreen';
 
 /**
- * ユーザー名とパスワードでWikidotにログインする
- * @param client - クライアントコンテキスト（AMCClientを持つオブジェクト）
- * @param username - ユーザー名
- * @param password - パスワード
- * @returns 成功時はvoid、失敗時はSessionCreateError
+ * Login to Wikidot with username and password
+ * @param client - Client context (object with AMCClient)
+ * @param username - Username
+ * @param password - Password
+ * @returns void on success, SessionCreateError on failure
  */
 export function login(
   client: AuthClientContext,
@@ -71,9 +71,9 @@ export function login(
 }
 
 /**
- * ログアウトする
- * @param client - クライアントコンテキスト（AMCClientを持つオブジェクト）
- * @returns 成功時はvoid
+ * Logout from Wikidot
+ * @param client - Client context (object with AMCClient)
+ * @returns void on success
  */
 export function logout(client: AuthClientContext): WikidotResultAsync<void> {
   // Try to logout via AMC, then always remove session cookie

--- a/src/module/client/accessors/pm-accessor.ts
+++ b/src/module/client/accessors/pm-accessor.ts
@@ -9,14 +9,14 @@ import type { User } from '../../user/user';
 import type { Client } from '../client';
 
 /**
- * プライベートメッセージ操作アクセサ
+ * Private message operations accessor
  *
  * @example
  * ```typescript
- * // 受信箱を取得
+ * // Get inbox
  * const inboxResult = await client.privateMessage.inbox();
  * if (!inboxResult.isOk()) {
- *   throw new Error('受信箱の取得に失敗しました');
+ *   throw new Error('Failed to get inbox');
  * }
  * const inbox = inboxResult.value;
  * ```
@@ -29,45 +29,45 @@ export class PrivateMessageAccessor {
   }
 
   /**
-   * メッセージIDからメッセージを取得する
+   * Get message by message ID
    *
-   * @param id - メッセージID
-   * @returns Result型でラップされたメッセージオブジェクト
+   * @param id - Message ID
+   * @returns Message object wrapped in Result type
    */
   get(id: number): WikidotResultAsync<PrivateMessage> {
     return PrivateMessage.fromId(this.client, id);
   }
 
   /**
-   * 複数のメッセージIDからメッセージを取得する
-   * @param ids - メッセージID配列
-   * @returns メッセージコレクション
+   * Get messages from multiple message IDs
+   * @param ids - Array of message IDs
+   * @returns Message collection
    */
   getMessages(ids: number[]): WikidotResultAsync<PrivateMessageCollection> {
     return PrivateMessageCollection.fromIds(this.client, ids);
   }
 
   /**
-   * 受信箱のメッセージ一覧を取得する
-   * @returns 受信箱
+   * Get inbox message list
+   * @returns Inbox
    */
   inbox(): WikidotResultAsync<PrivateMessageInbox> {
     return PrivateMessageInbox.acquire(this.client);
   }
 
   /**
-   * 送信箱のメッセージ一覧を取得する
-   * @returns 送信箱
+   * Get sent box message list
+   * @returns Sent box
    */
   sentBox(): WikidotResultAsync<PrivateMessageSentBox> {
     return PrivateMessageSentBox.acquire(this.client);
   }
 
   /**
-   * プライベートメッセージを送信する
-   * @param recipient - 受信者
-   * @param subject - 件名
-   * @param body - 本文
+   * Send a private message
+   * @param recipient - Recipient
+   * @param subject - Subject
+   * @param body - Body
    */
   send(recipient: User, subject: string, body: string): WikidotResultAsync<void> {
     return PrivateMessage.send(this.client, recipient, subject, body);

--- a/src/module/client/accessors/site-accessor.ts
+++ b/src/module/client/accessors/site-accessor.ts
@@ -3,7 +3,7 @@ import { Site } from '../../site';
 import type { Client } from '../client';
 
 /**
- * サイト操作アクセサ
+ * Site operations accessor
  */
 export class SiteAccessor {
   public readonly client: Client;
@@ -13,16 +13,16 @@ export class SiteAccessor {
   }
 
   /**
-   * UNIX名からサイトを取得する
+   * Get site by UNIX name
    *
-   * @param unixName - サイトのUNIX名（例: 'scp-jp'）
-   * @returns Result型でラップされたサイトオブジェクト
+   * @param unixName - Site UNIX name (e.g., 'scp-jp')
+   * @returns Site object wrapped in Result type
    *
    * @example
    * ```typescript
    * const siteResult = await client.site.get('scp-jp');
    * if (!siteResult.isOk()) {
-   *   throw new Error('サイトの取得に失敗しました');
+   *   throw new Error('Failed to get site');
    * }
    * const site = siteResult.value;
    * ```

--- a/src/module/client/accessors/user-accessor.ts
+++ b/src/module/client/accessors/user-accessor.ts
@@ -4,15 +4,15 @@ import { User, type UserCollection } from '../../user';
 import type { Client } from '../client';
 
 /**
- * ユーザー取得オプション
+ * User retrieval options
  */
 export interface GetUserOptions {
-  /** ユーザーが見つからない場合にエラーを発生させる（デフォルト: false） */
+  /** Throw error if user not found (default: false) */
   raiseWhenNotFound?: boolean;
 }
 
 /**
- * ユーザー操作アクセサ
+ * User operations accessor
  */
 export class UserAccessor {
   public readonly client: Client;
@@ -22,17 +22,17 @@ export class UserAccessor {
   }
 
   /**
-   * ユーザー名からユーザーを取得する
+   * Get user by username
    *
-   * @param name - ユーザー名
-   * @param options - 取得オプション
-   * @returns Result型でラップされたユーザー（存在しない場合はnull、raiseWhenNotFoundがtrueの場合はエラー）
+   * @param name - Username
+   * @param options - Retrieval options
+   * @returns User wrapped in Result type (null if not found, error if raiseWhenNotFound is true)
    *
    * @example
    * ```typescript
    * const userResult = await client.user.get('username');
    * if (!userResult.isOk()) {
-   *   throw new Error('ユーザーの取得に失敗しました');
+   *   throw new Error('Failed to get user');
    * }
    * const user = userResult.value;
    * ```
@@ -49,10 +49,10 @@ export class UserAccessor {
   }
 
   /**
-   * 複数ユーザー名からユーザーを取得する
-   * @param names - ユーザー名配列
-   * @param options - 取得オプション
-   * @returns ユーザーコレクション（存在しないユーザーはnull、raiseWhenNotFoundがtrueの場合はエラー）
+   * Get users from multiple usernames
+   * @param names - Array of usernames
+   * @param options - Retrieval options
+   * @returns User collection (null for non-existent users, error if raiseWhenNotFound is true)
    */
   getMany(names: string[], options: GetUserOptions = {}): WikidotResultAsync<UserCollection> {
     const { raiseWhenNotFound = false } = options;

--- a/src/module/forum/forum-category.ts
+++ b/src/module/forum/forum-category.ts
@@ -6,7 +6,7 @@ import type { Site } from '../site';
 import { ForumThread, ForumThreadCollection } from './forum-thread';
 
 /**
- * フォーラムカテゴリデータ
+ * Forum category data
  */
 export interface ForumCategoryData {
   site: Site;
@@ -18,7 +18,7 @@ export interface ForumCategoryData {
 }
 
 /**
- * フォーラムカテゴリ
+ * Forum category
  */
 export class ForumCategory {
   public readonly site: Site;
@@ -39,7 +39,7 @@ export class ForumCategory {
   }
 
   /**
-   * スレッド一覧を取得
+   * Get thread list
    */
   getThreads(): WikidotResultAsync<ForumThreadCollection> {
     if (this._threads !== null) {
@@ -60,7 +60,7 @@ export class ForumCategory {
   }
 
   /**
-   * スレッド一覧を再取得
+   * Reload thread list
    */
   reloadThreads(): WikidotResultAsync<ForumThreadCollection> {
     this._threads = null;
@@ -68,7 +68,7 @@ export class ForumCategory {
   }
 
   /**
-   * スレッドを作成
+   * Create thread
    */
   @RequireLogin
   createThread(
@@ -121,7 +121,7 @@ export class ForumCategory {
 }
 
 /**
- * フォーラムカテゴリコレクション
+ * Forum category collection
  */
 export class ForumCategoryCollection extends Array<ForumCategory> {
   public readonly site: Site;
@@ -135,14 +135,14 @@ export class ForumCategoryCollection extends Array<ForumCategory> {
   }
 
   /**
-   * IDで検索
+   * Find by ID
    */
   findById(id: number): ForumCategory | undefined {
     return this.find((category) => category.id === id);
   }
 
   /**
-   * サイトの全カテゴリを取得
+   * Get all categories for a site
    */
   static acquireAll(site: Site): WikidotResultAsync<ForumCategoryCollection> {
     return fromPromise(

--- a/src/module/forum/forum-thread.ts
+++ b/src/module/forum/forum-thread.ts
@@ -11,7 +11,7 @@ import type { ForumCategory } from './forum-category';
 import { ForumPostCollection } from './forum-post';
 
 /**
- * フォーラムスレッドデータ
+ * Forum thread data
  */
 export interface ForumThreadData {
   site: Site;
@@ -25,7 +25,7 @@ export interface ForumThreadData {
 }
 
 /**
- * フォーラムスレッド
+ * Forum thread
  */
 export class ForumThread {
   public readonly site: Site;
@@ -50,14 +50,14 @@ export class ForumThread {
   }
 
   /**
-   * スレッドURL
+   * Get thread URL
    */
   getUrl(): string {
     return `${this.site.getBaseUrl()}/forum/t-${this.id}/`;
   }
 
   /**
-   * 投稿一覧を取得
+   * Get post list
    */
   getPosts(): WikidotResultAsync<ForumPostCollection> {
     if (this._posts !== null) {
@@ -68,7 +68,7 @@ export class ForumThread {
   }
 
   /**
-   * スレッドに返信
+   * Reply to thread
    */
   @RequireLogin
   reply(
@@ -105,7 +105,7 @@ export class ForumThread {
   }
 
   /**
-   * IDからスレッドを取得
+   * Get thread by ID
    */
   static getFromId(
     site: Site,
@@ -133,7 +133,7 @@ export class ForumThread {
 }
 
 /**
- * フォーラムスレッドコレクション
+ * Forum thread collection
  */
 export class ForumThreadCollection extends Array<ForumThread> {
   public readonly site: Site;
@@ -147,14 +147,14 @@ export class ForumThreadCollection extends Array<ForumThread> {
   }
 
   /**
-   * IDで検索
+   * Find by ID
    */
   findById(id: number): ForumThread | undefined {
     return this.find((thread) => thread.id === id);
   }
 
   /**
-   * カテゴリ内の全スレッドを取得
+   * Get all threads in category
    */
   static acquireAllInCategory(category: ForumCategory): WikidotResultAsync<ForumThreadCollection> {
     return fromPromise(
@@ -193,7 +193,7 @@ export class ForumThreadCollection extends Array<ForumThread> {
           const description = $row.find('div.description').text().trim();
           const postCount = Number.parseInt($row.find('td.posts').text().trim(), 10) || 0;
 
-          // ユーザーと日時のパース
+          // Parse user and timestamp
           const $userElem = $row.find('td.started span.printuser');
           const $odateElem = $row.find('td.started span.odate');
 
@@ -270,7 +270,7 @@ export class ForumThreadCollection extends Array<ForumThread> {
             const description = $row.find('div.description').text().trim();
             const postCount = Number.parseInt($row.find('td.posts').text().trim(), 10) || 0;
 
-            // ユーザーと日時のパース
+            // Parse user and timestamp
             const $userElem = $row.find('td.started span.printuser');
             const $odateElem = $row.find('td.started span.odate');
 
@@ -308,9 +308,9 @@ export class ForumThreadCollection extends Array<ForumThread> {
   }
 
   /**
-   * スレッドIDから単一のスレッドを取得
-   * @param site - サイト
-   * @param threadId - スレッドID
+   * Get a single thread by thread ID
+   * @param site - Site instance
+   * @param threadId - Thread ID
    */
   static fromId(site: Site, threadId: number): WikidotResultAsync<ForumThread> {
     return fromPromise(
@@ -333,7 +333,7 @@ export class ForumThreadCollection extends Array<ForumThread> {
   }
 
   /**
-   * スレッドIDからスレッドを取得
+   * Get threads by thread IDs
    */
   static acquireFromThreadIds(
     site: Site,

--- a/src/module/page/page-file.ts
+++ b/src/module/page/page-file.ts
@@ -4,7 +4,7 @@ import { fromPromise, type WikidotResultAsync } from '../../common/types';
 import type { Page } from './page';
 
 /**
- * ページファイルデータ
+ * Page file data
  */
 export interface PageFileData {
   page: Page;
@@ -16,7 +16,7 @@ export interface PageFileData {
 }
 
 /**
- * ページ添付ファイル
+ * Page attachment file
  */
 export class PageFile {
   public readonly page: Page;
@@ -41,7 +41,7 @@ export class PageFile {
 }
 
 /**
- * ページファイルコレクション
+ * Page file collection
  */
 export class PageFileCollection extends Array<PageFile> {
   public readonly page: Page;
@@ -55,21 +55,21 @@ export class PageFileCollection extends Array<PageFile> {
   }
 
   /**
-   * IDで検索
+   * Find by ID
    */
   findById(id: number): PageFile | undefined {
     return this.find((file) => file.id === id);
   }
 
   /**
-   * 名前で検索
+   * Find by name
    */
   findByName(name: string): PageFile | undefined {
     return this.find((file) => file.name === name);
   }
 
   /**
-   * サイズ文字列をバイト数に変換
+   * Convert size string to bytes
    */
   private static parseSize(sizeText: string): number {
     const text = sizeText.trim();
@@ -89,7 +89,7 @@ export class PageFileCollection extends Array<PageFile> {
   }
 
   /**
-   * ページに添付されたファイル一覧を取得する
+   * Get list of files attached to page
    */
   static acquire(page: Page): WikidotResultAsync<PageFileCollection> {
     if (page.id === null) {

--- a/src/module/page/page-meta.ts
+++ b/src/module/page/page-meta.ts
@@ -3,7 +3,7 @@ import { fromPromise, type WikidotResultAsync } from '../../common/types';
 import type { PageRef } from '../types';
 
 /**
- * ページメタタグデータ
+ * Page meta tag data
  */
 export interface PageMetaData {
   page: PageRef;
@@ -12,7 +12,7 @@ export interface PageMetaData {
 }
 
 /**
- * ページメタタグ
+ * Page meta tag
  */
 export class PageMeta {
   public readonly page: PageRef;
@@ -26,15 +26,15 @@ export class PageMeta {
   }
 
   /**
-   * メタタグの値を更新する
-   * @param content - 新しい値
+   * Update meta tag value
+   * @param content - New value
    */
   update(content: string): WikidotResultAsync<void> {
     return PageMetaCollection.setMeta(this.page, this.name, content);
   }
 
   /**
-   * メタタグを削除する
+   * Delete meta tag
    */
   delete(): WikidotResultAsync<void> {
     return PageMetaCollection.deleteMeta(this.page, this.name);
@@ -46,7 +46,7 @@ export class PageMeta {
 }
 
 /**
- * ページメタタグコレクション
+ * Page meta tag collection
  */
 export class PageMetaCollection extends Array<PageMeta> {
   public readonly page: PageRef;
@@ -60,18 +60,18 @@ export class PageMetaCollection extends Array<PageMeta> {
   }
 
   /**
-   * 名前で検索
-   * @param name - メタタグ名
-   * @returns メタタグ（存在しない場合はundefined）
+   * Find by name
+   * @param name - Meta tag name
+   * @returns Meta tag (undefined if not found)
    */
   findByName(name: string): PageMeta | undefined {
     return this.find((meta) => meta.name === name);
   }
 
   /**
-   * ページのメタタグを取得する
-   * @param page - ページ参照
-   * @returns メタタグコレクション
+   * Get page meta tags
+   * @param page - Page reference
+   * @returns Meta tag collection
    */
   static acquire(page: PageRef): WikidotResultAsync<PageMetaCollection> {
     return fromPromise(
@@ -95,8 +95,8 @@ export class PageMetaCollection extends Array<PageMeta> {
         const html = String(response.body ?? '');
         const metas: PageMeta[] = [];
 
-        // HTMLエンコードされたメタタグを正規表現でパース
-        // 形式: &lt;meta name="xxx" content="yyy"/&gt;
+        // Parse HTML-encoded meta tags with regex
+        // Format: &lt;meta name="xxx" content="yyy"/&gt;
         const metaRegex = /&lt;meta name="([^"]+)" content="([^"]*)"\/?&gt;/g;
         for (const match of html.matchAll(metaRegex)) {
           const name = match[1];
@@ -124,10 +124,10 @@ export class PageMetaCollection extends Array<PageMeta> {
   }
 
   /**
-   * メタタグを設定する
-   * @param page - ページ参照
-   * @param name - メタタグ名
-   * @param content - メタタグの値
+   * Set meta tag
+   * @param page - Page reference
+   * @param name - Meta tag name
+   * @param content - Meta tag value
    */
   static setMeta(page: PageRef, name: string, content: string): WikidotResultAsync<void> {
     const loginResult = page.site.client.requireLogin();
@@ -165,9 +165,9 @@ export class PageMetaCollection extends Array<PageMeta> {
   }
 
   /**
-   * メタタグを削除する
-   * @param page - ページ参照
-   * @param name - メタタグ名
+   * Delete meta tag
+   * @param page - Page reference
+   * @param name - Meta tag name
    */
   static deleteMeta(page: PageRef, name: string): WikidotResultAsync<void> {
     const loginResult = page.site.client.requireLogin();

--- a/src/module/page/page-revision.ts
+++ b/src/module/page/page-revision.ts
@@ -6,7 +6,7 @@ import type { Page } from './page';
 import type { PageSource } from './page-source';
 
 /**
- * ページリビジョンデータ
+ * Page revision data
  */
 export interface PageRevisionData {
   page: Page;
@@ -18,31 +18,31 @@ export interface PageRevisionData {
 }
 
 /**
- * ページのリビジョン（編集履歴のバージョン）
+ * Page revision (version in edit history)
  */
 export class PageRevision {
-  /** リビジョンが属するページ */
+  /** Page this revision belongs to */
   public readonly page: Page;
 
-  /** リビジョンID */
+  /** Revision ID */
   public readonly id: number;
 
-  /** リビジョン番号 */
+  /** Revision number */
   public readonly revNo: number;
 
-  /** リビジョン作成者 */
+  /** Revision creator */
   public readonly createdBy: AbstractUser;
 
-  /** リビジョン作成日時 */
+  /** Revision creation date */
   public readonly createdAt: Date;
 
-  /** 編集コメント */
+  /** Edit comment */
   public readonly comment: string;
 
-  /** ソースコード（内部キャッシュ） */
+  /** Source code (internal cache) */
   private _source: PageSource | null = null;
 
-  /** HTML表示（内部キャッシュ） */
+  /** HTML display (internal cache) */
   private _html: string | null = null;
 
   constructor(data: PageRevisionData) {
@@ -55,55 +55,55 @@ export class PageRevision {
   }
 
   /**
-   * ソースコードが取得済みかどうか
+   * Whether source code has been acquired
    */
   isSourceAcquired(): boolean {
     return this._source !== null;
   }
 
   /**
-   * HTML表示が取得済みかどうか
+   * Whether HTML display has been acquired
    */
   isHtmlAcquired(): boolean {
     return this._html !== null;
   }
 
   /**
-   * ソースコード（キャッシュ済み）を取得
+   * Get source code (cached)
    */
   get source(): PageSource | null {
     return this._source;
   }
 
   /**
-   * ソースコードを設定
+   * Set source code
    */
   set source(value: PageSource | null) {
     this._source = value;
   }
 
   /**
-   * HTML表示（キャッシュ済み）を取得
+   * Get HTML display (cached)
    */
   get html(): string | null {
     return this._html;
   }
 
   /**
-   * HTML表示を設定
+   * Set HTML display
    */
   set html(value: string | null) {
     this._html = value;
   }
 
   /**
-   * リビジョンのソースを取得する（REV-001）
-   * @returns ソース文字列
+   * Get revision source (REV-001)
+   * @returns Source string
    */
   getSource(): WikidotResultAsync<string> {
     return fromPromise(
       (async () => {
-        // キャッシュがあれば返す
+        // Return cache if available
         if (this._source) {
           return this._source.wikiText;
         }
@@ -127,7 +127,7 @@ export class PageRevision {
         const html = String(response.body ?? '');
         const $ = cheerio.load(html);
 
-        // ソースコードは<div class="page-source">内にある
+        // Source code is inside <div class="page-source">
         const sourceElem = $('div.page-source');
         if (sourceElem.length === 0) {
           throw new NoElementError('Source element not found');
@@ -146,13 +146,13 @@ export class PageRevision {
   }
 
   /**
-   * リビジョンのHTMLを取得する（REV-002）
-   * @returns HTML文字列
+   * Get revision HTML (REV-002)
+   * @returns HTML string
    */
   getHtml(): WikidotResultAsync<string> {
     return fromPromise(
       (async () => {
-        // キャッシュがあれば返す
+        // Return cache if available
         if (this._html) {
           return this._html;
         }
@@ -176,10 +176,10 @@ export class PageRevision {
         const html = String(response.body ?? '');
         const $ = cheerio.load(html);
 
-        // HTMLコンテンツは<div id="page-content">内にある
+        // HTML content is inside <div id="page-content">
         const contentElem = $('#page-content');
         if (contentElem.length === 0) {
-          // page-contentがない場合はbody全体を返す
+          // Return entire body if page-content doesn't exist
           this._html = html;
           return html;
         }
@@ -203,7 +203,7 @@ export class PageRevision {
 }
 
 /**
- * ページリビジョンコレクション
+ * Page revision collection
  */
 export class PageRevisionCollection extends Array<PageRevision> {
   public readonly page: Page | null;
@@ -217,17 +217,17 @@ export class PageRevisionCollection extends Array<PageRevision> {
   }
 
   /**
-   * IDで検索
-   * @param id - リビジョンID
-   * @returns リビジョン（存在しない場合はundefined）
+   * Find by ID
+   * @param id - Revision ID
+   * @returns Revision (undefined if not found)
    */
   findById(id: number): PageRevision | undefined {
     return this.find((revision) => revision.id === id);
   }
 
   /**
-   * 全リビジョンのソースを一括取得する
-   * @returns ソース文字列の配列
+   * Get sources for all revisions
+   * @returns Array of source strings
    */
   getSources(): WikidotResultAsync<string[]> {
     return fromPromise(
@@ -253,8 +253,8 @@ export class PageRevisionCollection extends Array<PageRevision> {
   }
 
   /**
-   * 全リビジョンのHTMLを一括取得する
-   * @returns HTML文字列の配列
+   * Get HTML for all revisions
+   * @returns Array of HTML strings
    */
   getHtmls(): WikidotResultAsync<string[]> {
     return fromPromise(

--- a/src/module/page/page-source.ts
+++ b/src/module/page/page-source.ts
@@ -1,7 +1,7 @@
 import type { Page } from './page';
 
 /**
- * ページソースデータ
+ * Page source data
  */
 export interface PageSourceData {
   page: Page;
@@ -9,13 +9,13 @@ export interface PageSourceData {
 }
 
 /**
- * ページのソースコード（Wikidot記法）
+ * Page source code (Wikidot syntax)
  */
 export class PageSource {
-  /** ソースが属するページ */
+  /** Page this source belongs to */
   public readonly page: Page;
 
-  /** ソースコード（Wikidot記法） */
+  /** Source code (Wikidot syntax) */
   public readonly wikiText: string;
 
   constructor(data: PageSourceData) {

--- a/src/module/page/page-vote.ts
+++ b/src/module/page/page-vote.ts
@@ -2,7 +2,7 @@ import type { AbstractUser } from '../user';
 import type { Page } from './page';
 
 /**
- * ページ投票データ
+ * Page vote data
  */
 export interface PageVoteData {
   page: Page;
@@ -11,16 +11,16 @@ export interface PageVoteData {
 }
 
 /**
- * ページへの投票（レーティング）
+ * Page vote (rating)
  */
 export class PageVote {
-  /** 投票が属するページ */
+  /** Page this vote belongs to */
   public readonly page: Page;
 
-  /** 投票したユーザー */
+  /** User who voted */
   public readonly user: AbstractUser;
 
-  /** 投票値（+1/-1 または 数値） */
+  /** Vote value (+1/-1 or numeric) */
   public readonly value: number;
 
   constructor(data: PageVoteData) {
@@ -35,7 +35,7 @@ export class PageVote {
 }
 
 /**
- * ページ投票コレクション
+ * Page vote collection
  */
 export class PageVoteCollection extends Array<PageVote> {
   public readonly page: Page;
@@ -49,9 +49,9 @@ export class PageVoteCollection extends Array<PageVote> {
   }
 
   /**
-   * ユーザーで検索
-   * @param user - 検索するユーザー
-   * @returns 投票（存在しない場合はundefined）
+   * Find by user
+   * @param user - User to search for
+   * @returns Vote (undefined if not found)
    */
   findByUser(user: AbstractUser): PageVote | undefined {
     return this.find((vote) => vote.user.id === user.id);

--- a/src/module/page/page.ts
+++ b/src/module/page/page.ts
@@ -25,8 +25,8 @@ import { PageVote, PageVoteCollection } from './page-vote';
 import { DEFAULT_MODULE_BODY, DEFAULT_PER_PAGE, SearchPagesQuery } from './search-query';
 
 /**
- * ListPagesModuleパース結果のスキーマ
- * 型安全性のためにZodを使用してパース結果を検証
+ * Schema for ListPagesModule parse result
+ * Uses Zod for type-safe validation of parse results
  */
 const pageParamsSchema = z.object({
   fullname: z.preprocess((v) => v ?? '', z.string()),
@@ -51,7 +51,7 @@ const pageParamsSchema = z.object({
 });
 
 /**
- * ページデータ
+ * Page data
  */
 export interface PageData {
   site: Site;
@@ -77,7 +77,7 @@ export interface PageData {
 }
 
 /**
- * Wikidotページ
+ * Wikidot page
  */
 export class Page {
   public readonly site: Site;
@@ -130,77 +130,77 @@ export class Page {
   }
 
   /**
-   * ページURLを取得
+   * Get page URL
    */
   getUrl(): string {
     return `${this.site.getBaseUrl()}/${this.fullname}`;
   }
 
   /**
-   * ページIDが取得済みかどうか
+   * Whether page ID has been acquired
    */
   isIdAcquired(): boolean {
     return this._id !== null;
   }
 
   /**
-   * ページIDを取得
+   * Get page ID
    */
   get id(): number | null {
     return this._id;
   }
 
   /**
-   * ページIDを設定
+   * Set page ID
    */
   set id(value: number | null) {
     this._id = value;
   }
 
   /**
-   * ソースコードを取得
+   * Get source code
    */
   get source(): PageSource | null {
     return this._source;
   }
 
   /**
-   * ソースコードを設定
+   * Set source code
    */
   set source(value: PageSource | null) {
     this._source = value;
   }
 
   /**
-   * リビジョン履歴を取得
+   * Get revision history
    */
   get revisions(): PageRevisionCollection | null {
     return this._revisions;
   }
 
   /**
-   * リビジョン履歴を設定
+   * Set revision history
    */
   set revisions(value: PageRevisionCollection | null) {
     this._revisions = value;
   }
 
   /**
-   * 投票情報を取得
+   * Get vote information
    */
   get votes(): PageVoteCollection | null {
     return this._votes;
   }
 
   /**
-   * 投票情報を設定
+   * Set vote information
    */
   set votes(value: PageVoteCollection | null) {
     this._votes = value;
   }
 
   /**
-   * 最新リビジョンを取得
+   * Get latest revision
    */
   get latestRevision(): PageRevision | undefined {
     if (!this._revisions || this._revisions.length === 0) return undefined;
@@ -208,9 +208,9 @@ export class Page {
   }
 
   /**
-   * ページIDを確保する（未取得の場合は自動取得）
-   * @param operation - 操作名（エラーメッセージ用）
-   * @throws IDの取得に失敗した場合
+   * Ensure page ID is available (auto-acquire if not yet acquired)
+   * @param operation - Operation name (for error message)
+   * @throws If ID acquisition fails
    */
   private async ensureId(operation: string): Promise<number> {
     if (this._id === null) {
@@ -228,7 +228,7 @@ export class Page {
   }
 
   /**
-   * ページを削除する
+   * Delete page
    */
   @RequireLogin
   destroy(): WikidotResultAsync<void> {
@@ -252,7 +252,7 @@ export class Page {
   }
 
   /**
-   * タグを保存する
+   * Save tags
    */
   @RequireLogin
   commitTags(): WikidotResultAsync<void> {
@@ -277,8 +277,8 @@ export class Page {
   }
 
   /**
-   * 親ページを設定する
-   * @param parentFullname - 親ページのフルネーム（nullで解除）
+   * Set parent page
+   * @param parentFullname - Parent page fullname (null to remove)
    */
   @RequireLogin
   setParent(parentFullname: string | null): WikidotResultAsync<void> {
@@ -304,9 +304,9 @@ export class Page {
   }
 
   /**
-   * ページに投票する
-   * @param value - 投票値
-   * @returns 新しいレーティング
+   * Vote on page
+   * @param value - Vote value
+   * @returns New rating
    */
   @RequireLogin
   vote(value: number): WikidotResultAsync<number> {
@@ -339,8 +339,8 @@ export class Page {
   }
 
   /**
-   * 投票をキャンセルする
-   * @returns 新しいレーティング
+   * Cancel vote
+   * @returns New rating
    */
   @RequireLogin
   cancelVote(): WikidotResultAsync<number> {
@@ -371,8 +371,8 @@ export class Page {
   }
 
   /**
-   * ページを編集する
-   * @param options - 編集オプション
+   * Edit the page
+   * @param options - Edit options
    */
   @RequireLogin
   edit(options: {
@@ -385,19 +385,19 @@ export class Page {
       (async () => {
         const pageId = await this.ensureId('editing');
 
-        // 現在のソースを取得（指定がない場合）
+        // Get current source (if not specified)
         let currentSource = options.source;
         if (currentSource === undefined) {
           const existingSource = this._source;
           if (existingSource !== null) {
             currentSource = existingSource.wikiText;
           } else {
-            // ソースを取得
+            // Acquire source
             const sourceResult = await PageCollection.acquirePageSources(this.site, [this]);
             if (sourceResult.isErr()) {
               throw sourceResult.error;
             }
-            // acquirePageSources後、this._sourceにセットされる
+            // After acquirePageSources, this._source is set
             currentSource = this._source?.wikiText ?? '';
           }
         }
@@ -423,8 +423,8 @@ export class Page {
   }
 
   /**
-   * ページ名を変更する
-   * @param newFullname - 新しいフルネーム
+   * Rename the page
+   * @param newFullname - New fullname
    */
   @RequireLogin
   rename(newFullname: string): WikidotResultAsync<void> {
@@ -443,7 +443,7 @@ export class Page {
         if (result.isErr()) {
           throw result.error;
         }
-        // プロパティを更新（readonlyなのでObject.assignで）
+        // Update properties (using Object.assign since readonly)
         Object.assign(this, {
           fullname: newFullname,
           category: newFullname.includes(':') ? newFullname.split(':')[0] : '_default',
@@ -455,14 +455,14 @@ export class Page {
   }
 
   /**
-   * ページに添付されたファイル一覧を取得する
+   * Get list of files attached to the page
    */
   getFiles(): WikidotResultAsync<PageFileCollection> {
     return PageFileCollection.acquire(this);
   }
 
   /**
-   * ページのディスカッションスレッドを取得する
+   * Get the discussion thread for the page
    */
   getDiscussion(): WikidotResultAsync<import('../forum').ForumThread | null> {
     return fromPromise(
@@ -486,7 +486,7 @@ export class Page {
         }
 
         const html = String(response.body ?? '');
-        // スレッドIDを抽出
+        // Extract thread ID
         const match = html.match(
           /WIKIDOT\.modules\.ForumViewThreadModule\.vars\.threadId\s*=\s*(\d+)/
         );
@@ -496,7 +496,7 @@ export class Page {
 
         const threadId = Number.parseInt(match[1], 10);
 
-        // ForumThreadを取得
+        // Get ForumThread
         const { ForumThread } = await import('../forum');
         const threadResult = await ForumThread.getFromId(this.site, threadId);
         if (threadResult.isErr()) {
@@ -509,8 +509,8 @@ export class Page {
   }
 
   /**
-   * ページのメタタグ一覧を取得する
-   * @returns メタタグコレクション
+   * Get the list of meta tags for the page
+   * @returns Meta tag collection
    */
   getMetas(): WikidotResultAsync<PageMetaCollection> {
     return fromPromise(
@@ -527,9 +527,9 @@ export class Page {
   }
 
   /**
-   * メタタグを設定する
-   * @param name - メタタグ名
-   * @param content - メタタグの値
+   * Set a meta tag
+   * @param name - Meta tag name
+   * @param content - Meta tag value
    */
   @RequireLogin
   setMeta(name: string, content: string): WikidotResultAsync<void> {
@@ -546,8 +546,8 @@ export class Page {
   }
 
   /**
-   * メタタグを削除する
-   * @param name - メタタグ名
+   * Delete a meta tag
+   * @param name - Meta tag name
    */
   @RequireLogin
   deleteMeta(name: string): WikidotResultAsync<void> {
@@ -564,8 +564,8 @@ export class Page {
   }
 
   /**
-   * ページソースを取得する（未取得の場合は自動取得）
-   * @returns ページソース
+   * Get page source (auto-acquire if not yet acquired)
+   * @returns Page source
    */
   getSource(): WikidotResultAsync<PageSource> {
     return fromPromise(
@@ -593,8 +593,8 @@ export class Page {
   }
 
   /**
-   * リビジョン履歴を取得する（未取得の場合は自動取得）
-   * @returns リビジョンコレクション
+   * Get revision history (auto-acquire if not yet acquired)
+   * @returns Revision collection
    */
   getRevisions(): WikidotResultAsync<PageRevisionCollection> {
     return fromPromise(
@@ -622,8 +622,8 @@ export class Page {
   }
 
   /**
-   * 投票情報を取得する（未取得の場合は自動取得）
-   * @returns 投票コレクション
+   * Get vote information (auto-acquire if not yet acquired)
+   * @returns Vote collection
    */
   getVotes(): WikidotResultAsync<PageVoteCollection> {
     return fromPromise(
@@ -656,7 +656,7 @@ export class Page {
 }
 
 /**
- * ページコレクション
+ * Page collection
  */
 export class PageCollection extends Array<Page> {
   public readonly site: Site;
@@ -670,44 +670,44 @@ export class PageCollection extends Array<Page> {
   }
 
   /**
-   * フルネームで検索
-   * @param fullname - ページのフルネーム
-   * @returns ページ（存在しない場合はundefined）
+   * Find by fullname
+   * @param fullname - Page fullname
+   * @returns Page (undefined if not found)
    */
   findByFullname(fullname: string): Page | undefined {
     return this.find((page) => page.fullname === fullname);
   }
 
   /**
-   * ページIDを一括取得
+   * Acquire page IDs in bulk
    */
   getPageIds(): WikidotResultAsync<PageCollection> {
     return PageCollection.acquirePageIds(this.site, this);
   }
 
   /**
-   * ページソースを一括取得
+   * Acquire page sources in bulk
    */
   getPageSources(): WikidotResultAsync<PageCollection> {
     return PageCollection.acquirePageSources(this.site, this);
   }
 
   /**
-   * ページリビジョンを一括取得
+   * Acquire page revisions in bulk
    */
   getPageRevisions(): WikidotResultAsync<PageCollection> {
     return PageCollection.acquirePageRevisions(this.site, this);
   }
 
   /**
-   * ページ投票を一括取得
+   * Acquire page votes in bulk
    */
   getPageVotes(): WikidotResultAsync<PageCollection> {
     return PageCollection.acquirePageVotes(this.site, this);
   }
 
   /**
-   * ページIDを一括取得する内部メソッド
+   * Internal method to acquire page IDs in bulk
    */
   static acquirePageIds(site: Site, pages: Page[]): WikidotResultAsync<PageCollection> {
     return fromPromise(
@@ -718,10 +718,10 @@ export class PageCollection extends Array<Page> {
           return new PageCollection(site, pages);
         }
 
-        // 同時接続数を制限（AMCClientと同じsemaphoreLimitを使用）
+        // Limit concurrent connections (using same semaphoreLimit as AMCClient)
         const limit = pLimit(site.client.amcClient.config.semaphoreLimit);
 
-        // norender, noredirectでアクセス
+        // Access with norender, noredirect
         const responses = await Promise.all(
           targetPages.map((page) =>
             limit(async () => {
@@ -753,7 +753,7 @@ export class PageCollection extends Array<Page> {
   }
 
   /**
-   * ページソースを一括取得する内部メソッド
+   * Internal method to acquire page sources in bulk
    */
   static acquirePageSources(site: Site, pages: Page[]): WikidotResultAsync<PageCollection> {
     return fromPromise(
@@ -799,7 +799,7 @@ export class PageCollection extends Array<Page> {
   }
 
   /**
-   * ページリビジョンを一括取得する内部メソッド
+   * Internal method to acquire page revisions in bulk
    */
   static acquirePageRevisions(site: Site, pages: Page[]): WikidotResultAsync<PageCollection> {
     return fromPromise(
@@ -823,7 +823,7 @@ export class PageCollection extends Array<Page> {
           throw result.error;
         }
 
-        // リビジョンをパース
+        // Parse revisions
         for (let i = 0; i < targetPages.length; i++) {
           const page = targetPages[i];
           const response = result.value[i];
@@ -880,7 +880,7 @@ export class PageCollection extends Array<Page> {
   }
 
   /**
-   * ページ投票を一括取得する内部メソッド
+   * Internal method to acquire page votes in bulk
    */
   static acquirePageVotes(site: Site, pages: Page[]): WikidotResultAsync<PageCollection> {
     return fromPromise(
@@ -902,7 +902,7 @@ export class PageCollection extends Array<Page> {
           throw result.error;
         }
 
-        // 投票をパース
+        // Parse votes
         for (let i = 0; i < targetPages.length; i++) {
           const page = targetPages[i];
           const response = result.value[i];
@@ -948,7 +948,7 @@ export class PageCollection extends Array<Page> {
   }
 
   /**
-   * ListPagesModuleレスポンスをパース
+   * Parse ListPagesModule response
    */
   static parse(
     site: Site,
@@ -961,10 +961,10 @@ export class PageCollection extends Array<Page> {
       const $page = htmlBody(pageElement);
       const pageParams: Record<string, unknown> = {};
 
-      // 5つ星レーティング判定
+      // Check for 5-star rating
       const is5StarRating = $page.find('span.rating span.page-rate-list-pages-start').length > 0;
 
-      // 各値を取得
+      // Get each value
       $page.find('span.set').each((_j, setElement) => {
         const $set = htmlBody(setElement);
         const keyElement = $set.find('span.name');
@@ -1009,7 +1009,7 @@ export class PageCollection extends Array<Page> {
           value = valueElement.text().trim();
         }
 
-        // キー変換
+        // Key conversion
         if (key.includes('_linked')) {
           key = key.replace('_linked', '');
         } else if (['comments', 'children', 'revisions'].includes(key)) {
@@ -1021,15 +1021,15 @@ export class PageCollection extends Array<Page> {
         pageParams[key] = value;
       });
 
-      // タグ統合
+      // Merge tags
       const tags = Array.isArray(pageParams.tags) ? pageParams.tags : [];
       const hiddenTags = Array.isArray(pageParams._tags) ? pageParams._tags : [];
       pageParams.tags = [...tags, ...hiddenTags];
 
-      // Zodスキーマで検証・デフォルト値適用
+      // Validate with Zod schema and apply defaults
       const parsed = pageParamsSchema.parse(pageParams);
 
-      // Pageオブジェクト作成
+      // Create Page object
       pages.push(
         new Page({
           site,
@@ -1060,7 +1060,7 @@ export class PageCollection extends Array<Page> {
   }
 
   /**
-   * ページ検索
+   * Search pages
    */
   static searchPages(
     site: Site,
@@ -1072,7 +1072,7 @@ export class PageCollection extends Array<Page> {
         const q = query ?? new SearchPagesQuery();
         const queryDict = q.asDict();
 
-        // モジュールボディ生成
+        // Generate module body
         const moduleBody = `[[div class="page"]]\n${DEFAULT_MODULE_BODY.map(
           (key) =>
             `[[span class="set ${key}"]][[span class="name"]] ${key} [[/span]][[span class="value"]] %%${key}%% [[/span]][[/span]]`
@@ -1099,7 +1099,7 @@ export class PageCollection extends Array<Page> {
         let total = 1;
         const htmlBodies: cheerio.CheerioAPI[] = [$first];
 
-        // ページネーション確認
+        // Check pagination
         const pagerElement = $first('div.pager');
         if (pagerElement.length > 0) {
           const lastPagerElements = $first('div.pager span.target');
@@ -1112,7 +1112,7 @@ export class PageCollection extends Array<Page> {
           }
         }
 
-        // 追加ページ取得
+        // Get additional pages
         if (total > 1) {
           const additionalBodies: AMCRequestBody[] = [];
           for (let i = 1; i < total; i++) {
@@ -1135,7 +1135,7 @@ export class PageCollection extends Array<Page> {
           }
         }
 
-        // パース
+        // Parse
         const pages: Page[] = [];
         for (const $html of htmlBodies) {
           const parsed = PageCollection.parse(site, $html, parseUser);
@@ -1154,7 +1154,7 @@ export class PageCollection extends Array<Page> {
   }
 
   /**
-   * ページを作成または編集
+   * Create or edit a page
    */
   static createOrEdit(
     site: Site,
@@ -1187,7 +1187,7 @@ export class PageCollection extends Array<Page> {
           raiseOnExists = false,
         } = options;
 
-        // ページロック取得
+        // Acquire page lock
         const lockRequestBody: AMCRequestBody = {
           mode: 'page',
           wiki_page: fullname,
@@ -1221,7 +1221,7 @@ export class PageCollection extends Array<Page> {
         const lockSecret = String(lockResponse?.lock_secret ?? '');
         const pageRevisionId = String(lockResponse?.page_revision_id ?? '');
 
-        // ページ保存
+        // Save page
         const editRequestBody: AMCRequestBody = {
           action: 'WikiPageAction',
           event: 'savePage',

--- a/src/module/page/search-query.ts
+++ b/src/module/page/search-query.ts
@@ -1,56 +1,56 @@
 import type { AbstractUser } from '../user';
 
 /**
- * ページ検索クエリのパラメータ
+ * Page search query parameters
  */
 export interface SearchPagesQueryParams {
-  /** ページタイプ（例: 'normal', 'admin'） */
+  /** Page type (e.g., 'normal', 'admin') */
   pagetype?: string;
-  /** カテゴリ名 */
+  /** Category name */
   category?: string;
-  /** 検索対象タグ（AND条件） */
+  /** Tags to search (AND condition) */
   tags?: string | string[];
-  /** 親ページ名 */
+  /** Parent page name */
   parent?: string;
-  /** リンク先ページ名 */
+  /** Linked page name */
   linkTo?: string;
-  /** 作成日時条件 */
+  /** Created date condition */
   createdAt?: string;
-  /** 更新日時条件 */
+  /** Updated date condition */
   updatedAt?: string;
-  /** 作成者 */
+  /** Creator */
   createdBy?: AbstractUser | string;
-  /** レーティング条件 */
+  /** Rating condition */
   rating?: string;
-  /** 投票数条件 */
+  /** Vote count condition */
   votes?: string;
-  /** ページ名条件 */
+  /** Page name condition */
   name?: string;
-  /** フルネーム（完全一致） */
+  /** Fullname (exact match) */
   fullname?: string;
-  /** 範囲指定 */
+  /** Range specification */
   range?: string;
-  /** ソート順（例: 'created_at desc'） */
+  /** Sort order (e.g., 'created_at desc') */
   order?: string;
-  /** 取得開始位置 */
+  /** Start offset */
   offset?: number;
-  /** 取得件数制限 */
+  /** Result limit */
   limit?: number;
-  /** 1ページあたり件数 */
+  /** Items per page */
   perPage?: number;
-  /** 個別表示 */
+  /** Separate display */
   separate?: string;
-  /** ラッパー表示 */
+  /** Wrapper display */
   wrapper?: string;
 }
 
 /**
- * デフォルトの1ページあたり件数
+ * Default items per page
  */
 export const DEFAULT_PER_PAGE = 250;
 
 /**
- * デフォルトのモジュールボディフィールド
+ * Default module body fields
  */
 export const DEFAULT_MODULE_BODY = [
   'fullname',
@@ -76,46 +76,46 @@ export const DEFAULT_MODULE_BODY = [
 ] as const;
 
 /**
- * ページ検索クエリ
+ * Page search query
  */
 export class SearchPagesQuery {
-  /** ページタイプ */
+  /** Page type */
   pagetype: string;
-  /** カテゴリ */
+  /** Category */
   category: string;
-  /** タグ */
+  /** Tags */
   tags: string | string[] | null;
-  /** 親ページ */
+  /** Parent page */
   parent: string | null;
-  /** リンク先 */
+  /** Link target */
   linkTo: string | null;
-  /** 作成日時条件 */
+  /** Created date condition */
   createdAt: string | null;
-  /** 更新日時条件 */
+  /** Updated date condition */
   updatedAt: string | null;
-  /** 作成者 */
+  /** Creator */
   createdBy: AbstractUser | string | null;
-  /** レーティング条件 */
+  /** Rating condition */
   rating: string | null;
-  /** 投票数条件 */
+  /** Vote count condition */
   votes: string | null;
-  /** ページ名条件 */
+  /** Page name condition */
   name: string | null;
-  /** フルネーム条件 */
+  /** Fullname condition */
   fullname: string | null;
-  /** 範囲 */
+  /** Range */
   range: string | null;
-  /** ソート順 */
+  /** Sort order */
   order: string;
-  /** オフセット */
+  /** Offset */
   offset: number;
-  /** 取得件数制限 */
+  /** Result limit */
   limit: number | null;
-  /** 1ページあたり件数 */
+  /** Items per page */
   perPage: number;
-  /** 個別表示 */
+  /** Separate display */
   separate: string;
-  /** ラッパー表示 */
+  /** Wrapper display */
   wrapper: string;
 
   constructor(params: SearchPagesQueryParams = {}) {
@@ -141,7 +141,7 @@ export class SearchPagesQuery {
   }
 
   /**
-   * 辞書形式に変換
+   * Convert to dictionary format
    */
   asDict(): Record<string, unknown> {
     const result: Record<string, unknown> = {};

--- a/src/module/page/site-change.ts
+++ b/src/module/page/site-change.ts
@@ -6,7 +6,7 @@ import type { Site } from '../site';
 import type { AbstractUser } from '../user';
 
 /**
- * サイト変更履歴データ
+ * Site change history data
  */
 export interface SiteChangeData {
   site: Site;
@@ -20,7 +20,7 @@ export interface SiteChangeData {
 }
 
 /**
- * サイト変更履歴
+ * Site change history
  */
 export class SiteChange {
   public readonly site: Site;
@@ -44,7 +44,7 @@ export class SiteChange {
   }
 
   /**
-   * ページURL
+   * Get page URL
    */
   getPageUrl(): string {
     return `${this.site.getBaseUrl()}/${this.pageFullname}`;
@@ -56,7 +56,7 @@ export class SiteChange {
 }
 
 /**
- * サイト変更履歴コレクション
+ * Site change history collection
  */
 export class SiteChangeCollection extends Array<SiteChange> {
   public readonly site: Site;
@@ -70,10 +70,10 @@ export class SiteChangeCollection extends Array<SiteChange> {
   }
 
   /**
-   * 最近の変更履歴を取得する
-   * @param site - サイト
-   * @param options - オプション
-   * @returns 変更履歴コレクション
+   * Get recent change history
+   * @param site - Site instance
+   * @param options - Options
+   * @returns Change history collection
    */
   static acquire(
     site: Site,
@@ -106,24 +106,24 @@ export class SiteChangeCollection extends Array<SiteChange> {
         const $ = cheerio.load(html);
         const changes: SiteChange[] = [];
 
-        // テーブル行をパース
+        // Parse table rows
         $('table.wiki-content-table tr').each((_i, elem) => {
           const $row = $(elem);
           const $cells = $row.find('td');
           if ($cells.length < 4) return;
 
-          // ページリンク
+          // Page link
           const pageLink = $($cells[0]).find('a');
           const href = pageLink.attr('href') ?? '';
           const pageFullname = href.replace(/^\//, '').split('/')[0] ?? '';
           const pageTitle = pageLink.text().trim();
 
-          // リビジョン番号
+          // Revision number
           const revText = $($cells[1]).text().trim();
           const revMatch = revText.match(/(\d+)/);
           const revisionNo = revMatch?.[1] ? Number.parseInt(revMatch[1], 10) : 0;
 
-          // フラグ
+          // Flags
           const flagsCell = $($cells[2]);
           const flags: string[] = [];
           flagsCell.find('span').each((_j, flagElem) => {
@@ -134,7 +134,7 @@ export class SiteChangeCollection extends Array<SiteChange> {
             }
           });
 
-          // ユーザーと日時
+          // User and timestamp
           const infoCell = $($cells[3]);
           const userElem = infoCell.find('span.printuser');
           const changedBy = userElem.length > 0 ? parseUser(site.client, userElem) : null;
@@ -142,7 +142,7 @@ export class SiteChangeCollection extends Array<SiteChange> {
           const odateElem = infoCell.find('span.odate');
           const changedAt = odateElem.length > 0 ? parseOdate(odateElem) : null;
 
-          // コメント
+          // Comment
           const commentElem = infoCell.find('span.comments');
           const comment = commentElem
             .text()
@@ -163,7 +163,7 @@ export class SiteChangeCollection extends Array<SiteChange> {
           );
         });
 
-        // limitが指定されている場合は結果を制限
+        // Limit results if limit is specified
         const limitedChanges = limit !== undefined ? changes.slice(0, limit) : changes;
         return new SiteChangeCollection(site, limitedChanges);
       })(),

--- a/src/module/private-message/private-message.ts
+++ b/src/module/private-message/private-message.ts
@@ -12,7 +12,7 @@ import type { AbstractUser } from '../user';
 import type { User } from '../user/user';
 
 /**
- * プライベートメッセージデータ
+ * Private message data
  */
 export interface PrivateMessageData {
   client: Client;
@@ -25,7 +25,7 @@ export interface PrivateMessageData {
 }
 
 /**
- * プライベートメッセージ
+ * Private message
  */
 export class PrivateMessage {
   public readonly client: Client;
@@ -47,10 +47,10 @@ export class PrivateMessage {
   }
 
   /**
-   * メッセージIDからメッセージを取得する
-   * @param client - クライアント
-   * @param messageId - メッセージID
-   * @returns プライベートメッセージ
+   * Get message by message ID
+   * @param client - Client instance
+   * @param messageId - Message ID
+   * @returns Private message
    */
   static fromId(client: Client, messageId: number): WikidotResultAsync<PrivateMessage> {
     return fromPromise(
@@ -75,11 +75,11 @@ export class PrivateMessage {
   }
 
   /**
-   * プライベートメッセージを送信する
-   * @param client - クライアント
-   * @param recipient - 受信者
-   * @param subject - 件名
-   * @param body - 本文
+   * Send private message
+   * @param client - Client instance
+   * @param recipient - Recipient
+   * @param subject - Subject
+   * @param body - Body
    */
   static send(
     client: Client,
@@ -121,7 +121,7 @@ export class PrivateMessage {
 }
 
 /**
- * プライベートメッセージコレクション
+ * Private message collection
  */
 export class PrivateMessageCollection extends Array<PrivateMessage> {
   public readonly client: Client;
@@ -135,14 +135,14 @@ export class PrivateMessageCollection extends Array<PrivateMessage> {
   }
 
   /**
-   * IDで検索
+   * Find by ID
    */
   findById(id: number): PrivateMessage | undefined {
     return this.find((message) => message.id === id);
   }
 
   /**
-   * メッセージIDのリストからメッセージを取得する
+   * Get messages from list of message IDs
    */
   static fromIds(
     client: Client,
@@ -178,7 +178,7 @@ export class PrivateMessageCollection extends Array<PrivateMessage> {
           const html = String(response.body ?? '');
           const $ = cheerio.load(html);
 
-          // ユーザー情報を取得
+          // Get user information
           const printuserElems = $('div.pmessage div.header span.printuser');
           if (printuserElems.length < 2) {
             throw new ForbiddenError(`Failed to get message: ${messageId}`);
@@ -190,15 +190,15 @@ export class PrivateMessageCollection extends Array<PrivateMessage> {
           const sender = parseUser(client, senderElem);
           const recipient = parseUser(client, recipientElem);
 
-          // 件名
+          // Subject
           const subjectElem = $('div.pmessage div.header span.subject');
           const subject = subjectElem.text().trim();
 
-          // 本文
+          // Body
           const bodyElem = $('div.pmessage div.body');
           const body = bodyElem.text().trim();
 
-          // 日時
+          // Timestamp
           const odateElem = $('div.header span.odate');
           const createdAt =
             odateElem.length > 0 ? (parseOdate(odateElem) ?? new Date(0)) : new Date(0);
@@ -228,7 +228,7 @@ export class PrivateMessageCollection extends Array<PrivateMessage> {
   }
 
   /**
-   * モジュールからメッセージを取得する内部メソッド
+   * Internal method to get messages from module
    */
   protected static acquireFromModule(
     client: Client,
@@ -244,7 +244,7 @@ export class PrivateMessageCollection extends Array<PrivateMessage> {
 
     return fromPromise(
       (async () => {
-        // ページャー取得
+        // Get pager
         const firstResult = await client.amcClient.request([{ moduleName }]);
         if (firstResult.isErr()) {
           throw firstResult.error;
@@ -258,7 +258,7 @@ export class PrivateMessageCollection extends Array<PrivateMessage> {
         const firstHtml = String(firstResponse.body ?? '');
         const $first = cheerio.load(firstHtml);
 
-        // ページ数を取得
+        // Get page count
         const pagerTargets = $first('div.pager span.target');
         let maxPage = 1;
         if (pagerTargets.length > 2) {
@@ -268,7 +268,7 @@ export class PrivateMessageCollection extends Array<PrivateMessage> {
           maxPage = Number.parseInt(lastPageText, 10) || 1;
         }
 
-        // 全ページからメッセージIDを取得
+        // Get message IDs from all pages
         const messageIds: number[] = [];
 
         if (maxPage > 1) {
@@ -302,7 +302,7 @@ export class PrivateMessageCollection extends Array<PrivateMessage> {
           });
         }
 
-        // メッセージを取得
+        // Get messages
         const messagesResult = await PrivateMessageCollection.fromIds(client, messageIds);
         if (messagesResult.isErr()) {
           throw messagesResult.error;
@@ -325,11 +325,11 @@ export class PrivateMessageCollection extends Array<PrivateMessage> {
 }
 
 /**
- * 受信箱
+ * Inbox
  */
 export class PrivateMessageInbox extends PrivateMessageCollection {
   /**
-   * 受信箱のメッセージをすべて取得する
+   * Get all messages in inbox
    */
   static acquire(client: Client): WikidotResultAsync<PrivateMessageInbox> {
     return fromPromise(
@@ -356,11 +356,11 @@ export class PrivateMessageInbox extends PrivateMessageCollection {
 }
 
 /**
- * 送信箱
+ * Sent box
  */
 export class PrivateMessageSentBox extends PrivateMessageCollection {
   /**
-   * 送信箱のメッセージをすべて取得する
+   * Get all messages in sent box
    */
   static acquire(client: Client): WikidotResultAsync<PrivateMessageSentBox> {
     return fromPromise(

--- a/src/module/site/accessors/forum-accessor.ts
+++ b/src/module/site/accessors/forum-accessor.ts
@@ -9,7 +9,7 @@ import {
 import type { Site } from '../site';
 
 /**
- * フォーラム操作アクセサ
+ * Forum operations accessor
  */
 export class ForumAccessor {
   public readonly site: Site;
@@ -19,26 +19,26 @@ export class ForumAccessor {
   }
 
   /**
-   * フォーラムカテゴリ一覧を取得
-   * @returns カテゴリ一覧
+   * Get forum category list
+   * @returns Category list
    */
   getCategories(): WikidotResultAsync<ForumCategoryCollection> {
     return ForumCategoryCollection.acquireAll(this.site);
   }
 
   /**
-   * スレッドを取得
-   * @param threadId - スレッドID
-   * @returns スレッド
+   * Get thread
+   * @param threadId - Thread ID
+   * @returns Thread
    */
   getThread(threadId: number): WikidotResultAsync<ForumThread> {
     return ForumThread.getFromId(this.site, threadId);
   }
 
   /**
-   * 複数スレッドを取得
-   * @param threadIds - スレッドID配列
-   * @returns スレッドコレクション
+   * Get multiple threads
+   * @param threadIds - Array of thread IDs
+   * @returns Thread collection
    */
   getThreads(threadIds: number[]): WikidotResultAsync<ForumThreadCollection> {
     return ForumThreadCollection.acquireFromThreadIds(this.site, threadIds);

--- a/src/module/site/accessors/member-accessor.ts
+++ b/src/module/site/accessors/member-accessor.ts
@@ -13,7 +13,7 @@ import { SiteApplication } from '../site-application';
 import { SiteMember } from '../site-member';
 
 /**
- * サイトメンバー操作アクセサ
+ * Site member operations accessor
  */
 export class MemberAccessor {
   public readonly site: Site;
@@ -23,50 +23,50 @@ export class MemberAccessor {
   }
 
   /**
-   * 全メンバーを取得する
-   * @returns メンバー一覧
+   * Get all members
+   * @returns Member list
    */
   getAll(): WikidotResultAsync<SiteMember[]> {
     return SiteMember.getMembers(this.site, '');
   }
 
   /**
-   * モデレーター一覧を取得する
-   * @returns モデレーター一覧
+   * Get moderator list
+   * @returns Moderator list
    */
   getModerators(): WikidotResultAsync<SiteMember[]> {
     return SiteMember.getMembers(this.site, 'moderators');
   }
 
   /**
-   * 管理者一覧を取得する
-   * @returns 管理者一覧
+   * Get admin list
+   * @returns Admin list
    */
   getAdmins(): WikidotResultAsync<SiteMember[]> {
     return SiteMember.getMembers(this.site, 'admins');
   }
 
   /**
-   * 未処理の参加申請を取得する
-   * @returns 参加申請一覧
+   * Get pending membership applications
+   * @returns Application list
    */
   getApplications(): WikidotResultAsync<SiteApplication[]> {
     return SiteApplication.acquireAll(this.site);
   }
 
   /**
-   * メンバーを検索する
-   * @param query - 検索クエリ（ユーザー名の一部）
-   * @returns マッチしたユーザー一覧（QMCUser形式）
+   * Search members
+   * @param query - Search query (part of username)
+   * @returns Matched user list (QMCUser format)
    */
   lookup(query: string): WikidotResultAsync<QMCUser[]> {
     return QuickModule.memberLookup(this.site.id, query);
   }
 
   /**
-   * ユーザーをサイトに招待する
-   * @param user - 招待するユーザー
-   * @param text - 招待メッセージ
+   * Invite user to site
+   * @param user - User to invite
+   * @param text - Invitation message
    */
   @RequireLogin
   invite(user: User, text: string): WikidotResultAsync<void> {

--- a/src/module/site/accessors/page-accessor.ts
+++ b/src/module/site/accessors/page-accessor.ts
@@ -5,7 +5,7 @@ import { Page, PageCollection, SearchPagesQuery } from '../../page';
 import type { Site } from '../site';
 
 /**
- * 単一ページ操作アクセサ
+ * Single page operations accessor
  */
 export class PageAccessor {
   public readonly site: Site;
@@ -15,9 +15,9 @@ export class PageAccessor {
   }
 
   /**
-   * UNIX名からページを取得する
-   * @param unixName - ページのUNIX名（例: 'scp-173'）
-   * @returns ページ（存在しない場合はnull）
+   * Get page by UNIX name
+   * @param unixName - Page UNIX name (e.g., 'scp-173')
+   * @returns Page (null if not found)
    */
   get(unixName: string): WikidotResultAsync<Page | null> {
     return fromPromise(
@@ -40,9 +40,9 @@ export class PageAccessor {
   }
 
   /**
-   * ページを作成する
-   * @param fullname - ページのフルネーム（例: 'scp-173'）
-   * @param options - 作成オプション
+   * Create a page
+   * @param fullname - Page fullname (e.g., 'scp-173')
+   * @param options - Creation options
    * @returns void
    */
   create(

--- a/src/module/site/accessors/pages-accessor.ts
+++ b/src/module/site/accessors/pages-accessor.ts
@@ -11,7 +11,7 @@ import {
 import type { Site } from '../site';
 
 /**
- * ページ一覧操作アクセサ
+ * Page list operations accessor
  */
 export class PagesAccessor {
   public readonly site: Site;
@@ -21,9 +21,9 @@ export class PagesAccessor {
   }
 
   /**
-   * 条件に合うページを検索する
-   * @param params - 検索条件
-   * @returns ページコレクション
+   * Search pages matching conditions
+   * @param params - Search conditions
+   * @returns Page collection
    */
   search(params?: SearchPagesQueryParams): WikidotResultAsync<PageCollection> {
     return fromPromise(
@@ -43,19 +43,19 @@ export class PagesAccessor {
   }
 
   /**
-   * 全ページを取得する
-   * @returns ページコレクション
+   * Get all pages
+   * @returns Page collection
    */
   all(): WikidotResultAsync<PageCollection> {
     return this.search({});
   }
 
   /**
-   * 最近の変更履歴を取得する
-   * @param options - オプション
-   * @param options.perPage - 1ページあたりの件数（デフォルト: 20）
-   * @param options.page - ページ番号（デフォルト: 1）
-   * @returns 変更履歴コレクション
+   * Get recent changes
+   * @param options - Options
+   * @param options.perPage - Items per page (default: 20)
+   * @param options.page - Page number (default: 1)
+   * @returns Change history collection
    */
   getRecentChanges(options?: {
     perPage?: number;

--- a/src/module/site/site-application.ts
+++ b/src/module/site/site-application.ts
@@ -13,7 +13,7 @@ import type { AbstractUser } from '../user';
 import type { Site } from './site';
 
 /**
- * サイト参加申請データ
+ * Site membership application data
  */
 export interface SiteApplicationData {
   site: Site;
@@ -22,7 +22,7 @@ export interface SiteApplicationData {
 }
 
 /**
- * サイト参加申請
+ * Site membership application
  */
 export class SiteApplication {
   public readonly site: Site;
@@ -36,8 +36,8 @@ export class SiteApplication {
   }
 
   /**
-   * 未処理の参加申請をすべて取得する
-   * @param site - 対象サイト
+   * Get all pending membership applications
+   * @param site - Target site
    */
   static acquireAll(site: Site): WikidotResultAsync<SiteApplication[]> {
     const loginResult = site.client.requireLogin();
@@ -65,7 +65,7 @@ export class SiteApplication {
 
         const html = String(response.body ?? '');
 
-        // 権限チェック
+        // Permission check
         if (html.includes('WIKIDOT.page.listeners.loginClick(event)')) {
           throw new ForbiddenError('You are not allowed to access this page');
         }
@@ -107,7 +107,7 @@ export class SiteApplication {
   }
 
   /**
-   * 申請を処理する内部メソッド
+   * Internal method to process application
    */
   @RequireLogin
   private process(action: 'accept' | 'decline'): WikidotResultAsync<void> {
@@ -141,14 +141,14 @@ export class SiteApplication {
   }
 
   /**
-   * 参加申請を承認する
+   * Accept membership application
    */
   accept(): WikidotResultAsync<void> {
     return this.process('accept');
   }
 
   /**
-   * 参加申請を拒否する
+   * Decline membership application
    */
   decline(): WikidotResultAsync<void> {
     return this.process('decline');

--- a/src/module/site/site-member.ts
+++ b/src/module/site/site-member.ts
@@ -12,7 +12,7 @@ import type { AbstractUser } from '../user';
 import type { Site } from './site';
 
 /**
- * サイトメンバーデータ
+ * Site member data
  */
 export interface SiteMemberData {
   site: Site;
@@ -21,7 +21,7 @@ export interface SiteMemberData {
 }
 
 /**
- * サイトメンバー
+ * Site member
  */
 export class SiteMember {
   public readonly site: Site;
@@ -35,7 +35,7 @@ export class SiteMember {
   }
 
   /**
-   * HTMLからメンバー情報をパースする
+   * Parse member information from HTML
    */
   private static parse(site: Site, html: string): SiteMember[] {
     const $ = cheerio.load(html);
@@ -51,7 +51,7 @@ export class SiteMember {
 
       const user = parseUser(site.client, userElem);
 
-      // 2つ目のtdがあれば加入日時
+      // Second td contains join date if exists
       let joinedAt: Date | null = null;
       if (tds.length >= 2) {
         const odateElem = $(tds[1]).find('.odate');
@@ -67,9 +67,9 @@ export class SiteMember {
   }
 
   /**
-   * サイトメンバー一覧を取得する
-   * @param site - 対象サイト
-   * @param group - グループ（"admins", "moderators", または空文字で全メンバー）
+   * Get site member list
+   * @param site - Target site
+   * @param group - Group ("admins", "moderators", or empty string for all members)
    */
   static getMembers(
     site: Site,
@@ -79,7 +79,7 @@ export class SiteMember {
       (async () => {
         const members: SiteMember[] = [];
 
-        // 最初のページを取得
+        // Get first page
         const firstResult = await site.amcRequest([
           {
             moduleName: 'membership/MembersListModule',
@@ -100,7 +100,7 @@ export class SiteMember {
         const firstHtml = String(firstResponse.body ?? '');
         members.push(...SiteMember.parse(site, firstHtml));
 
-        // ページャーを確認
+        // Check pager
         const $first = cheerio.load(firstHtml);
         const pagerLinks = $first('div.pager a');
         if (pagerLinks.length < 2) {
@@ -115,7 +115,7 @@ export class SiteMember {
           return members;
         }
 
-        // 残りのページを取得
+        // Get remaining pages
         const bodies = [];
         for (let page = 2; page <= lastPage; page++) {
           bodies.push({
@@ -142,7 +142,7 @@ export class SiteMember {
   }
 
   /**
-   * グループ変更の内部メソッド
+   * Internal method to change group
    */
   @RequireLogin
   private changeGroup(
@@ -183,28 +183,28 @@ export class SiteMember {
   }
 
   /**
-   * モデレーターに昇格
+   * Promote to moderator
    */
   toModerator(): WikidotResultAsync<void> {
     return this.changeGroup('toModerators');
   }
 
   /**
-   * モデレーター権限を削除
+   * Remove moderator privileges
    */
   removeModerator(): WikidotResultAsync<void> {
     return this.changeGroup('removeModerator');
   }
 
   /**
-   * 管理者に昇格
+   * Promote to admin
    */
   toAdmin(): WikidotResultAsync<void> {
     return this.changeGroup('toAdmins');
   }
 
   /**
-   * 管理者権限を削除
+   * Remove admin privileges
    */
   removeAdmin(): WikidotResultAsync<void> {
     return this.changeGroup('removeAdmin');

--- a/src/module/site/site.ts
+++ b/src/module/site/site.ts
@@ -9,7 +9,7 @@ import { PageAccessor } from './accessors/page-accessor';
 import { PagesAccessor } from './accessors/pages-accessor';
 
 /**
- * サイトデータ
+ * Site data
  */
 export interface SiteData {
   id: number;
@@ -20,36 +20,36 @@ export interface SiteData {
 }
 
 /**
- * サイトクラス
+ * Site class
  */
 export class Site {
   public readonly client: Client;
 
-  /** サイトID */
+  /** Site ID */
   public readonly id: number;
 
-  /** サイトタイトル */
+  /** Site title */
   public readonly title: string;
 
-  /** UNIX名（例: scp-jp） */
+  /** UNIX name (e.g., scp-jp) */
   public readonly unixName: string;
 
-  /** ドメイン */
+  /** Domain */
   public readonly domain: string;
 
-  /** SSL対応フラグ */
+  /** SSL support flag */
   public readonly sslSupported: boolean;
 
-  /** ページアクセサ */
+  /** Page accessor */
   private _page: PageAccessor | null = null;
 
-  /** ページ一覧アクセサ */
+  /** Pages accessor */
   private _pages: PagesAccessor | null = null;
 
-  /** フォーラムアクセサ */
+  /** Forum accessor */
   private _forum: ForumAccessor | null = null;
 
-  /** メンバーアクセサ */
+  /** Member accessor */
   private _member: MemberAccessor | null = null;
 
   constructor(client: Client, data: SiteData) {
@@ -62,7 +62,7 @@ export class Site {
   }
 
   /**
-   * ページアクセサを取得
+   * Get page accessor
    */
   get page(): PageAccessor {
     if (!this._page) {
@@ -72,7 +72,7 @@ export class Site {
   }
 
   /**
-   * ページ一覧アクセサを取得
+   * Get pages accessor
    */
   get pages(): PagesAccessor {
     if (!this._pages) {
@@ -82,7 +82,7 @@ export class Site {
   }
 
   /**
-   * フォーラムアクセサを取得
+   * Get forum accessor
    */
   get forum(): ForumAccessor {
     if (!this._forum) {
@@ -92,7 +92,7 @@ export class Site {
   }
 
   /**
-   * メンバーアクセサを取得
+   * Get member accessor
    */
   get member(): MemberAccessor {
     if (!this._member) {
@@ -102,7 +102,7 @@ export class Site {
   }
 
   /**
-   * サイトのベースURLを取得
+   * Get base URL of the site
    */
   getBaseUrl(): string {
     const protocol = this.sslSupported ? 'https' : 'http';
@@ -110,18 +110,18 @@ export class Site {
   }
 
   /**
-   * サイトへのAMCリクエストを実行
-   * @param bodies - リクエストボディ配列
-   * @returns AMCレスポンス配列
+   * Execute AMC request to this site
+   * @param bodies - Request body array
+   * @returns AMC response array
    */
   amcRequest(bodies: AMCRequestBody[]): WikidotResultAsync<AMCResponse[]> {
     return this.client.amcClient.request(bodies, this.unixName, this.sslSupported);
   }
 
   /**
-   * 単一のAMCリクエストを実行
-   * @param body - リクエストボディ
-   * @returns AMCレスポンス
+   * Execute a single AMC request
+   * @param body - Request body
+   * @returns AMC response
    */
   amcRequestSingle(body: AMCRequestBody): WikidotResultAsync<AMCResponse> {
     return fromPromise(
@@ -146,15 +146,15 @@ export class Site {
   }
 
   /**
-   * UNIX名からサイトを取得する
-   * @param client - クライアント
-   * @param unixName - サイトのUNIX名（例: 'scp-jp'）
-   * @returns サイト
+   * Get site from UNIX name
+   * @param client - Client
+   * @param unixName - Site UNIX name (e.g., 'scp-jp')
+   * @returns Site
    */
   static fromUnixName(client: Client, unixName: string): WikidotResultAsync<Site> {
     return fromPromise(
       (async () => {
-        // サイトページを取得（HTTPでリクエストし、リダイレクトに従う）
+        // Fetch site page (HTTP request, following redirects)
         const url = `http://${unixName}.wikidot.com`;
         const response = await fetch(url, {
           headers: client.amcClient.header.getHeaders(),
@@ -170,7 +170,7 @@ export class Site {
         const html = await response.text();
         const $ = cheerio.load(html);
 
-        // WIKIREQUEST.info を解析
+        // Parse WIKIREQUEST.info
         const scripts = $('script').toArray();
         let siteId: number | null = null;
         let siteUnixName: string | null = null;
@@ -224,7 +224,7 @@ export class Site {
           title = unixName; // Fallback
         }
 
-        // SSL対応チェック（リダイレクト後のURLがhttpsで始まるかどうかで判断）
+        // Check SSL support (based on whether the redirect URL starts with https)
         const sslSupported = response.url.startsWith('https');
 
         return new Site(client, {

--- a/src/module/types.ts
+++ b/src/module/types.ts
@@ -1,29 +1,29 @@
 /**
- * 循環依存を避けるための共通インターフェース定義
+ * Common interface definitions to avoid circular dependencies
  */
 
 import type { WikidotResultAsync } from '../common/types';
 import type { AMCRequestBody, AMCResponse } from '../connector';
 
 /**
- * クライアント参照インターフェース
- * Client型への直接依存を避けるために使用
+ * Client reference interface
+ * Used to avoid direct dependency on Client type
  */
 export interface ClientRef {
   /**
-   * ログインが必要な操作の前に呼び出す
-   * @returns ログインしていない場合はエラー
+   * Call before operations that require login
+   * @returns Error if not logged in
    */
   requireLogin(): { isErr(): boolean; error?: Error };
 
   /**
-   * ログイン済みかどうか
+   * Whether logged in
    */
   isLoggedIn(): boolean;
 }
 
 /**
- * AMCHeaderの最小インターフェース
+ * Minimal AMCHeader interface
  */
 export interface AMCHeaderRef {
   getHeaders(): Record<string, string>;
@@ -32,7 +32,7 @@ export interface AMCHeaderRef {
 }
 
 /**
- * AMCClientの最小インターフェース
+ * Minimal AMCClient interface
  */
 export interface AMCClientRef {
   header: AMCHeaderRef;
@@ -40,127 +40,127 @@ export interface AMCClientRef {
 }
 
 /**
- * 認証処理で必要なクライアントコンテキスト
- * auth.tsがclient.tsに直接依存することを避けるために使用
+ * Client context required for authentication
+ * Used to avoid auth.ts directly depending on client.ts
  */
 export interface AuthClientContext {
   amcClient: AMCClientRef;
 }
 
 /**
- * サイト参照インターフェース
- * Site型への直接依存を避けるために使用
+ * Site reference interface
+ * Used to avoid direct dependency on Site type
  */
 export interface SiteRef {
   /**
-   * サイトID
+   * Site ID
    */
   readonly id: number;
 
   /**
-   * UNIX名（例: scp-jp）
+   * UNIX name (e.g., scp-jp)
    */
   readonly unixName: string;
 
   /**
-   * ドメイン
+   * Domain
    */
   readonly domain: string;
 
   /**
-   * SSL対応フラグ
+   * SSL support flag
    */
   readonly sslSupported: boolean;
 
   /**
-   * クライアント参照
+   * Client reference
    */
   readonly client: ClientRef;
 
   /**
-   * AMCリクエストを実行
+   * Execute AMC request
    */
   amcRequest(bodies: AMCRequestBody[]): WikidotResultAsync<AMCResponse[]>;
 
   /**
-   * 単一のAMCリクエストを実行
+   * Execute single AMC request
    */
   amcRequestSingle(body: AMCRequestBody): WikidotResultAsync<AMCResponse>;
 }
 
 /**
- * フォーラムカテゴリ参照インターフェース
+ * Forum category reference interface
  */
 export interface ForumCategoryRef {
   /**
-   * カテゴリID
+   * Category ID
    */
   readonly id: number;
 
   /**
-   * カテゴリタイトル
+   * Category title
    */
   readonly title: string;
 
   /**
-   * サイト参照
+   * Site reference
    */
   readonly site: SiteRef;
 }
 
 /**
- * フォーラムスレッド参照インターフェース
- * ForumThread型への直接依存を避けるために使用
+ * Forum thread reference interface
+ * Used to avoid direct dependency on ForumThread type
  */
 export interface ForumThreadRef {
   /**
-   * スレッドID
+   * Thread ID
    */
   readonly id: number;
 
   /**
-   * スレッドタイトル
+   * Thread title
    */
   readonly title: string;
 
   /**
-   * サイト参照
+   * Site reference
    */
   readonly site: SiteRef;
 
   /**
-   * カテゴリ参照（存在する場合）
+   * Category reference (if exists)
    */
   readonly category?: ForumCategoryRef | null;
 }
 
 /**
- * ページ参照インターフェース
- * Page型への直接依存を避けるために使用
+ * Page reference interface
+ * Used to avoid direct dependency on Page type
  */
 export interface PageRef {
   /**
-   * ページID（取得後に設定される）
+   * Page ID (set after retrieval)
    */
   readonly id: number | null;
 
   /**
-   * フルネーム（category:name 形式）
+   * Fullname (category:name format)
    */
   readonly fullname: string;
 
   /**
-   * ページ名
+   * Page name
    */
   readonly name: string;
 
   /**
-   * カテゴリ
+   * Category
    */
   readonly category: string;
 
   /**
-   * サイト参照
+   * Site reference
    */
   readonly site: SiteRef;
 }

--- a/src/module/user/abstract-user.ts
+++ b/src/module/user/abstract-user.ts
@@ -1,36 +1,36 @@
 import type { ClientRef } from '../types';
 
 /**
- * ユーザー種別
+ * User type
  */
 export type UserType = 'user' | 'deleted' | 'anonymous' | 'guest' | 'wikidot';
 
 /**
- * ユーザー基底インターフェース
+ * User base interface
  */
 export interface AbstractUser {
-  /** クライアント */
+  /** Client */
   readonly client: ClientRef;
 
-  /** ユーザーID */
+  /** User ID */
   readonly id: number;
 
-  /** ユーザー名 */
+  /** Username */
   readonly name: string;
 
-  /** UNIX形式のユーザー名 */
+  /** UNIX format username */
   readonly unixName: string | null;
 
-  /** アバターURL */
+  /** Avatar URL */
   readonly avatarUrl: string | null;
 
-  /** IPアドレス（匿名ユーザーの場合のみ） */
+  /** IP address (only for anonymous users) */
   readonly ip: string | null;
 
-  /** ユーザー種別 */
+  /** User type */
   readonly userType: UserType;
 
-  /** ユーザー種別を判定 */
+  /** Check user type */
   isUser(): boolean;
   isDeletedUser(): boolean;
   isAnonymousUser(): boolean;

--- a/src/module/user/anonymous-user.ts
+++ b/src/module/user/anonymous-user.ts
@@ -2,27 +2,27 @@ import type { ClientRef } from '../types';
 import type { AbstractUser, UserType } from './abstract-user';
 
 /**
- * 匿名ユーザー
+ * Anonymous user
  */
 export class AnonymousUser implements AbstractUser {
   public readonly client: ClientRef;
 
-  /** ユーザーID（匿名は0） */
+  /** User ID (0 for anonymous) */
   public readonly id: number = 0;
 
-  /** ユーザー名（匿名は"Anonymous"） */
+  /** Username ("Anonymous" for anonymous users) */
   public readonly name: string = 'Anonymous';
 
-  /** UNIX形式のユーザー名 */
+  /** UNIX format username */
   public readonly unixName: string = 'anonymous';
 
-  /** アバターURL（匿名はnull） */
+  /** Avatar URL (null for anonymous) */
   public readonly avatarUrl: string | null = null;
 
-  /** IPアドレス */
+  /** IP address */
   public readonly ip: string;
 
-  /** ユーザー種別 */
+  /** User type */
   public readonly userType: UserType = 'anonymous';
 
   constructor(client: ClientRef, ip: string) {
@@ -30,7 +30,7 @@ export class AnonymousUser implements AbstractUser {
     this.ip = ip;
   }
 
-  // AbstractUser実装
+  // AbstractUser implementation
   isUser(): boolean {
     return false;
   }

--- a/src/module/user/deleted-user.ts
+++ b/src/module/user/deleted-user.ts
@@ -2,27 +2,27 @@ import type { ClientRef } from '../types';
 import type { AbstractUser, UserType } from './abstract-user';
 
 /**
- * 削除済みユーザー
+ * Deleted user
  */
 export class DeletedUser implements AbstractUser {
   public readonly client: ClientRef;
 
-  /** 削除済みユーザーID */
+  /** Deleted user ID */
   public readonly id: number;
 
-  /** ユーザー名（削除済みは"account deleted"） */
+  /** Username ("account deleted" for deleted users) */
   public readonly name: string = 'account deleted';
 
-  /** UNIX形式のユーザー名 */
+  /** UNIX format username */
   public readonly unixName: string = 'account_deleted';
 
-  /** アバターURL（削除済みはnull） */
+  /** Avatar URL (null for deleted) */
   public readonly avatarUrl: string | null = null;
 
-  /** IPアドレス（削除済みはnull） */
+  /** IP address (null for deleted) */
   public readonly ip: string | null = null;
 
-  /** ユーザー種別 */
+  /** User type */
   public readonly userType: UserType = 'deleted';
 
   constructor(client: ClientRef, id: number) {
@@ -30,7 +30,7 @@ export class DeletedUser implements AbstractUser {
     this.id = id;
   }
 
-  // AbstractUser実装
+  // AbstractUser implementation
   isUser(): boolean {
     return false;
   }

--- a/src/module/user/guest-user.ts
+++ b/src/module/user/guest-user.ts
@@ -2,27 +2,27 @@ import type { ClientRef } from '../types';
 import type { AbstractUser, UserType } from './abstract-user';
 
 /**
- * ゲストユーザー
+ * Guest user
  */
 export class GuestUser implements AbstractUser {
   public readonly client: ClientRef;
 
-  /** ユーザーID（ゲストは0） */
+  /** User ID (0 for guest) */
   public readonly id: number = 0;
 
-  /** ゲスト名 */
+  /** Guest name */
   public readonly name: string;
 
-  /** UNIX形式のユーザー名（ゲストはnull） */
+  /** UNIX format username (null for guest) */
   public readonly unixName: string | null = null;
 
-  /** アバターURL（Gravatarの場合あり） */
+  /** Avatar URL (may be Gravatar) */
   public readonly avatarUrl: string | null;
 
-  /** IPアドレス（ゲストはnull） */
+  /** IP address (null for guest) */
   public readonly ip: string | null = null;
 
-  /** ユーザー種別 */
+  /** User type */
   public readonly userType: UserType = 'guest';
 
   constructor(client: ClientRef, name: string, avatarUrl: string | null = null) {
@@ -31,7 +31,7 @@ export class GuestUser implements AbstractUser {
     this.avatarUrl = avatarUrl;
   }
 
-  // AbstractUser実装
+  // AbstractUser implementation
   isUser(): boolean {
     return false;
   }

--- a/src/module/user/user-collection.ts
+++ b/src/module/user/user-collection.ts
@@ -1,7 +1,7 @@
 import type { User } from './user';
 
 /**
- * ユーザーコレクション
+ * User collection
  */
 export class UserCollection extends Array<User | null> {
   constructor(users?: (User | null)[]) {
@@ -12,9 +12,9 @@ export class UserCollection extends Array<User | null> {
   }
 
   /**
-   * ユーザー名で検索
-   * @param name - ユーザー名
-   * @returns ユーザーまたはundefined
+   * Find by username
+   * @param name - Username
+   * @returns User or undefined
    */
   findByName(name: string): User | undefined {
     const lowerName = name.toLowerCase();
@@ -27,9 +27,9 @@ export class UserCollection extends Array<User | null> {
   }
 
   /**
-   * ユーザーIDで検索
-   * @param id - ユーザーID
-   * @returns ユーザーまたはundefined
+   * Find by user ID
+   * @param id - User ID
+   * @returns User or undefined
    */
   findById(id: number): User | undefined {
     for (const user of this) {
@@ -41,8 +41,8 @@ export class UserCollection extends Array<User | null> {
   }
 
   /**
-   * nullを除いたユーザーのみを返す
-   * @returns null以外のユーザー配列
+   * Return only non-null users
+   * @returns Array of non-null users
    */
   filterNonNull(): User[] {
     return this.filter((user): user is User => user !== null);

--- a/src/module/user/user.ts
+++ b/src/module/user/user.ts
@@ -9,7 +9,7 @@ import type { AbstractUser, UserType } from './abstract-user';
 import { UserCollection } from './user-collection';
 
 /**
- * ユーザーデータ
+ * User data
  */
 export interface UserData {
   id: number;
@@ -20,30 +20,30 @@ export interface UserData {
 }
 
 /**
- * 通常ユーザー
+ * Regular user
  */
 export class User implements AbstractUser {
   public readonly client: ClientRef;
 
-  /** ユーザーID */
+  /** User ID */
   public readonly id: number;
 
-  /** ユーザー名 */
+  /** Username */
   public readonly name: string;
 
-  /** 表示名 */
+  /** Display name */
   public readonly displayName: string | null;
 
-  /** アバターURL */
+  /** Avatar URL */
   public readonly avatarUrl: string | null;
 
-  /** UNIX形式のユーザー名 */
+  /** UNIX format username */
   public readonly unixName: string;
 
-  /** IPアドレス（通常ユーザーではnull） */
+  /** IP address (null for regular users) */
   public readonly ip: string | null = null;
 
-  /** ユーザー種別 */
+  /** User type */
   public readonly userType: UserType = 'user';
 
   constructor(client: ClientRef, data: UserData) {
@@ -56,10 +56,10 @@ export class User implements AbstractUser {
   }
 
   /**
-   * ユーザー名からユーザーを取得する
-   * @param client - クライアント
-   * @param name - ユーザー名
-   * @returns ユーザー（存在しない場合はnull）
+   * Get user from username
+   * @param client - Client
+   * @param name - Username
+   * @returns User (null if not found)
    */
   static fromName(client: ClientRef, name: string): WikidotResultAsync<User | null> {
     return fromPromise(
@@ -75,12 +75,12 @@ export class User implements AbstractUser {
         const html = await response.text();
         const $ = cheerio.load(html);
 
-        // 存在チェック
+        // Check existence
         if ($('div.error-block').length > 0) {
           return null;
         }
 
-        // id取得
+        // Get id
         const userIdElem = $('a.btn.btn-default.btn-xs');
         if (userIdElem.length === 0) {
           throw new NoElementError('User ID element not found');
@@ -91,7 +91,7 @@ export class User implements AbstractUser {
         }
         const userId = Number.parseInt(href.split('/').pop() ?? '0', 10);
 
-        // name取得
+        // Get name
         const nameElem = $('h1.profile-title');
         if (nameElem.length === 0) {
           throw new NoElementError('User name element not found');
@@ -114,15 +114,15 @@ export class User implements AbstractUser {
   }
 
   /**
-   * 複数ユーザー名からユーザーを取得する
-   * @param client - クライアント
-   * @param names - ユーザー名配列
-   * @returns ユーザーコレクション
+   * Get users from multiple usernames
+   * @param client - Client
+   * @param names - Array of usernames
+   * @returns User collection
    */
   static fromNames(client: ClientRef, names: string[]): WikidotResultAsync<UserCollection> {
     return fromPromise(
       (async () => {
-        // 同時接続数を制限
+        // Limit concurrent connections
         const limit = pLimit(DEFAULT_AMC_CONFIG.semaphoreLimit);
 
         const results = await Promise.all(
@@ -139,7 +139,7 @@ export class User implements AbstractUser {
     );
   }
 
-  // AbstractUser実装
+  // AbstractUser implementation
   isUser(): boolean {
     return true;
   }

--- a/src/module/user/wikidot-user.ts
+++ b/src/module/user/wikidot-user.ts
@@ -2,34 +2,34 @@ import type { ClientRef } from '../types';
 import type { AbstractUser, UserType } from './abstract-user';
 
 /**
- * Wikidotシステムユーザー
+ * Wikidot system user
  */
 export class WikidotUser implements AbstractUser {
   public readonly client: ClientRef;
 
-  /** ユーザーID（Wikidotシステムは0） */
+  /** User ID (0 for Wikidot system) */
   public readonly id: number = 0;
 
-  /** ユーザー名 */
+  /** Username */
   public readonly name: string = 'Wikidot';
 
-  /** UNIX形式のユーザー名 */
+  /** UNIX format username */
   public readonly unixName: string = 'wikidot';
 
-  /** アバターURL（システムユーザーはnull） */
+  /** Avatar URL (null for system user) */
   public readonly avatarUrl: string | null = null;
 
-  /** IPアドレス（システムユーザーはnull） */
+  /** IP address (null for system user) */
   public readonly ip: string | null = null;
 
-  /** ユーザー種別 */
+  /** User type */
   public readonly userType: UserType = 'wikidot';
 
   constructor(client: ClientRef) {
     this.client = client;
   }
 
-  // AbstractUser実装
+  // AbstractUser implementation
   isUser(): boolean {
     return false;
   }

--- a/src/util/parser/user.ts
+++ b/src/util/parser/user.ts
@@ -6,30 +6,30 @@ import type { AbstractUser } from '../../module/user';
 import { AnonymousUser, DeletedUser, GuestUser, User, WikidotUser } from '../../module/user';
 
 /**
- * printuser要素をパースし、ユーザーオブジェクトを返す
+ * Parse printuser element and return user object
  *
- * @param client - Wikidotクライアント
- * @param elem - パース対象の要素（printuserクラスがついた要素）
- * @returns パースされて得られたユーザーオブジェクト
+ * @param client - Wikidot client
+ * @param elem - Element to parse (element with printuser class)
+ * @returns Parsed user object
  */
 export function parseUser(client: ClientRef, elem: cheerio.Cheerio<AnyNode>): AbstractUser {
   const classAttr = elem.attr('class') ?? '';
   const classes = classAttr.split(/\s+/);
 
-  // 削除済みユーザー判定
+  // Check for deleted user
   if (classes.includes('deleted')) {
     const dataId = elem.attr('data-id');
     const userId = dataId ? Number.parseInt(dataId, 10) : 0;
     return new DeletedUser(client, userId);
   }
 
-  // テキストが "(user deleted)" の場合
+  // If text is "(user deleted)"
   const text = elem.text().trim();
   if (text === '(user deleted)') {
     return new DeletedUser(client, 0);
   }
 
-  // 匿名ユーザー判定
+  // Check for anonymous user
   if (classes.includes('anonymous')) {
     const ipElem = elem.find('span.ip');
     if (ipElem.length > 0) {
@@ -39,7 +39,7 @@ export function parseUser(client: ClientRef, elem: cheerio.Cheerio<AnyNode>): Ab
     return new AnonymousUser(client, '');
   }
 
-  // ゲストユーザー判定（Gravatarアバターを持つ）
+  // Check for guest user (has Gravatar avatar)
   const imgElem = elem.find('img');
   if (imgElem.length > 0) {
     const src = imgElem.attr('src') ?? '';
@@ -49,33 +49,33 @@ export function parseUser(client: ClientRef, elem: cheerio.Cheerio<AnyNode>): Ab
     }
   }
 
-  // Wikidotシステムユーザー判定
+  // Check for Wikidot system user
   if (text === 'Wikidot') {
     return new WikidotUser(client);
   }
 
-  // 通常ユーザー
+  // Regular user
   const links = elem.find('a');
   if (links.length === 0) {
-    // リンクがない場合はDeletedUserとして扱う
+    // Treat as DeletedUser if no link
     return new DeletedUser(client, 0);
   }
 
-  // 最後のリンクがユーザーリンク
+  // Last link is the user link
   const userLink = links.last();
   const userName = userLink.text().trim();
   const href = userLink.attr('href') ?? '';
   const onclick = userLink.attr('onclick') ?? '';
 
-  // unix_nameをhrefから抽出
+  // Extract unix_name from href
   const unixName = href.replace(/^.*\/user:info\//, '').replace(/\/$/, '');
 
-  // user_idをonclickから抽出
-  // パターン: "WIKIDOT.page.listeners.userInfo(123456); return false;"
+  // Extract user_id from onclick
+  // Pattern: "WIKIDOT.page.listeners.userInfo(123456); return false;"
   const userIdMatch = onclick.match(/userInfo\((\d+)\)/);
   const userId = userIdMatch?.[1] ? Number.parseInt(userIdMatch[1], 10) : 0;
 
-  // アバターURLを生成
+  // Generate avatar URL
   const avatarUrl = userId > 0 ? `http://www.wikidot.com/avatar.php?userid=${userId}` : undefined;
 
   return new User(client, {
@@ -87,30 +87,30 @@ export function parseUser(client: ClientRef, elem: cheerio.Cheerio<AnyNode>): Ab
 }
 
 /**
- * odate要素から日時をパースする
+ * Parse date from odate element
  *
- * @param elem - パース対象の要素（odate要素）
- * @returns パースされたDate、パース失敗時はnull
+ * @param elem - Element to parse (odate element)
+ * @returns Parsed Date, or null on parse failure
  */
 export function parseOdate(elem: cheerio.Cheerio<AnyNode>): Date | null {
   const classAttr = elem.attr('class') ?? '';
 
-  // クラスから Unix タイムスタンプを抽出
-  // パターン: "odate time_1234567890 format_..." のような形式
+  // Extract Unix timestamp from class
+  // Pattern: "odate time_1234567890 format_..." format
   const timeMatch = classAttr.match(/time_(\d+)/);
   if (timeMatch?.[1]) {
     const unixTime = Number.parseInt(timeMatch[1], 10);
     return new Date(unixTime * 1000);
   }
 
-  // フォールバック: テキストからパース
+  // Fallback: parse from text
   const text = elem.text().trim();
   const parsed = Date.parse(text);
   if (!Number.isNaN(parsed)) {
     return new Date(parsed);
   }
 
-  // パースできない場合はnullを返却し、警告をログ出力
+  // Return null and log warning if parsing fails
   logger.warn(`Failed to parse odate element: class="${classAttr}", text="${text}"`);
   return null;
 }

--- a/src/util/quick-module.ts
+++ b/src/util/quick-module.ts
@@ -1,7 +1,7 @@
 /**
- * QuickModule - Wikidot軽量API
+ * QuickModule - Wikidot lightweight API
  *
- * quickmodule.phpエンドポイントを使用した検索機能
+ * Search functionality using quickmodule.php endpoint
  */
 
 import { z } from 'zod';
@@ -9,12 +9,12 @@ import { NotFoundException, UnexpectedError } from '../common/errors';
 import { fromPromise, type WikidotResultAsync } from '../common/types';
 
 /**
- * QuickModuleモジュール名
+ * QuickModule module name
  */
 export type QuickModuleName = 'MemberLookupQModule' | 'UserLookupQModule' | 'PageLookupQModule';
 
 /**
- * QuickModuleユーザー情報
+ * QuickModule user information
  */
 export interface QMCUser {
   id: number;
@@ -22,7 +22,7 @@ export interface QMCUser {
 }
 
 /**
- * QuickModuleページ情報
+ * QuickModule page information
  */
 export interface QMCPage {
   title: string;
@@ -30,7 +30,7 @@ export interface QMCPage {
 }
 
 /**
- * QuickModuleレスポンススキーマ
+ * QuickModule response schema
  */
 const quickModuleUserResponseSchema = z.object({
   users: z.union([
@@ -57,7 +57,7 @@ const quickModulePageResponseSchema = z.object({
 });
 
 /**
- * QuickModuleエンドポイントにリクエストを送信
+ * Send request to QuickModule endpoint
  */
 async function requestQuickModule(
   moduleName: QuickModuleName,
@@ -85,10 +85,10 @@ async function requestQuickModule(
 }
 
 /**
- * サイトメンバーを検索
- * @param siteId - サイトID
- * @param query - 検索クエリ（ユーザー名の一部）
- * @returns マッチしたユーザー一覧
+ * Search site members
+ * @param siteId - Site ID
+ * @param query - Search query (partial username)
+ * @returns List of matching users
  */
 export function memberLookup(siteId: number, query: string): WikidotResultAsync<QMCUser[]> {
   return fromPromise(
@@ -113,10 +113,10 @@ export function memberLookup(siteId: number, query: string): WikidotResultAsync<
 }
 
 /**
- * Wikidot全体からユーザーを検索
- * @param siteId - サイトID（任意のサイトIDで可）
- * @param query - 検索クエリ（ユーザー名の一部）
- * @returns マッチしたユーザー一覧
+ * Search users across all Wikidot
+ * @param siteId - Site ID (any site ID works)
+ * @param query - Search query (partial username)
+ * @returns List of matching users
  */
 export function userLookup(siteId: number, query: string): WikidotResultAsync<QMCUser[]> {
   return fromPromise(
@@ -141,10 +141,10 @@ export function userLookup(siteId: number, query: string): WikidotResultAsync<QM
 }
 
 /**
- * サイト内のページを検索
- * @param siteId - サイトID
- * @param query - 検索クエリ（ページ名の一部）
- * @returns マッチしたページ一覧
+ * Search pages within site
+ * @param siteId - Site ID
+ * @param query - Search query (partial page name)
+ * @returns List of matching pages
  */
 export function pageLookup(siteId: number, query: string): WikidotResultAsync<QMCPage[]> {
   return fromPromise(
@@ -169,8 +169,8 @@ export function pageLookup(siteId: number, query: string): WikidotResultAsync<QM
 }
 
 /**
- * QuickModule API（後方互換性のため維持）
- * @deprecated 代わりに個別の関数（memberLookup, userLookup, pageLookup）を使用してください
+ * QuickModule API (maintained for backwards compatibility)
+ * @deprecated Use individual functions (memberLookup, userLookup, pageLookup) instead
  */
 export const QuickModule: {
   memberLookup: typeof memberLookup;

--- a/src/util/string-util.ts
+++ b/src/util/string-util.ts
@@ -1,34 +1,34 @@
 /**
- * 文字列ユーティリティ
+ * String utilities
  */
 
 import { specialCharMap } from './table/char-table';
 
 /**
- * 文字列をUnix形式に変換する
+ * Convert string to Unix format
  *
- * legacy wikidotの実装に合わせた変換を行う。
- * - 特殊文字をASCII文字に変換
- * - 小文字に変換
- * - ASCII以外の文字をハイフンに変換
- * - 連続するハイフン/コロンを単一に
- * - 先頭/末尾のハイフン/コロンを削除
+ * Performs conversion following legacy wikidot implementation.
+ * - Converts special characters to ASCII characters
+ * - Converts to lowercase
+ * - Converts non-ASCII characters to hyphens
+ * - Reduces consecutive hyphens/colons to single
+ * - Removes leading/trailing hyphens/colons
  *
- * @param targetStr - 変換対象の文字列
- * @returns 変換された文字列
+ * @param targetStr - String to convert
+ * @returns Converted string
  */
 export function toUnix(targetStr: string): string {
-  // 特殊文字の変換
+  // Convert special characters
   let result = '';
   for (const char of targetStr) {
     const mapped = specialCharMap[char];
     result += mapped !== undefined ? mapped : char;
   }
 
-  // lowercaseへの変換
+  // Convert to lowercase
   result = result.toLowerCase();
 
-  // ascii以外の文字を削除
+  // Remove non-ASCII characters
   result = result.replace(/[^a-z0-9\-:_]/g, '-');
   result = result.replace(/^_/, ':_');
   result = result.replace(/(?<!:)_/g, '-');
@@ -41,7 +41,7 @@ export function toUnix(targetStr: string): string {
   result = result.replace(/_-/g, '_');
   result = result.replace(/-_/g, '_');
 
-  // 先頭と末尾の:を削除
+  // Remove leading and trailing colons
   result = result.replace(/^:/, '');
   result = result.replace(/:$/, '');
 
@@ -49,7 +49,7 @@ export function toUnix(targetStr: string): string {
 }
 
 /**
- * StringUtilクラス（Python互換）
+ * StringUtil class (Python compatible)
  */
 export const StringUtil = {
   toUnix,

--- a/src/util/table/char-table.ts
+++ b/src/util/table/char-table.ts
@@ -1,8 +1,8 @@
 /**
- * 特殊記号・非英語アルファベットを英語アルファベットに変換するためのマッピングテーブル
+ * Mapping table for converting special symbols and non-English alphabets to English alphabets
  *
- * 非ASCII文字を対応するASCII文字に変換するためのマッピングを提供する。
- * 主にURL生成やページ名のunix形式への変換時に使用される。
+ * Provides mapping for converting non-ASCII characters to corresponding ASCII characters.
+ * Mainly used for URL generation and page name conversion to unix format.
  */
 
 export const specialCharMap: Record<string, string> = {

--- a/tests/fixtures/loader.ts
+++ b/tests/fixtures/loader.ts
@@ -1,7 +1,7 @@
 /**
  * Fixture Loader
  *
- * テストフィクスチャを読み込むユーティリティ
+ * Utility for loading test fixtures
  */
 
 import { readFileSync } from 'node:fs';
@@ -11,7 +11,7 @@ import { fileURLToPath } from 'node:url';
 const __dirname = dirname(fileURLToPath(import.meta.url));
 
 /**
- * HTMLフィクスチャを読み込む
+ * Load HTML fixture
  */
 export function loadHtmlFixture(filename: string): string {
   const path = join(__dirname, 'html_samples', filename);
@@ -19,7 +19,7 @@ export function loadHtmlFixture(filename: string): string {
 }
 
 /**
- * JSONフィクスチャを読み込む
+ * Load JSON fixture
  */
 export function loadJsonFixture<T = Record<string, unknown>>(subdir: string, filename: string): T {
   const path = join(__dirname, 'amc_responses', subdir, filename);
@@ -27,7 +27,7 @@ export function loadJsonFixture<T = Record<string, unknown>>(subdir: string, fil
   return JSON.parse(content) as T;
 }
 
-// HTMLフィクスチャローダー
+// HTML fixture loader
 export const htmlFixtures = {
   // Printuser
   printuserRegular: () => loadHtmlFixture('printuser_regular.html'),
@@ -50,7 +50,7 @@ export const htmlFixtures = {
   userProfileNotFound: () => loadHtmlFixture('user_profile_notfound.html'),
 };
 
-// AMCレスポンスフィクスチャローダー
+// AMC response fixture loader
 export const amcFixtures = {
   // Page
   page: {
@@ -112,7 +112,7 @@ export const amcFixtures = {
 };
 
 /**
- * odate HTMLファクトリ
+ * odate HTML factory
  */
 export function createOdateHtml(unixTimestamp: number): string {
   return `<span class="odate time_${unixTimestamp} format_%25e%20%25b%20%25Y%2C%20%25H%3A%25M%7Cagohover" style="cursor: help; display: inline;">17 Dec 2025, 12:00</span>`;

--- a/tests/integration/README.md
+++ b/tests/integration/README.md
@@ -1,86 +1,86 @@
-# 統合テスト
+# Integration Tests
 
-## 概要
+## Overview
 
-このディレクトリには、実際のWikidotサーバー（ukwhatn-ci.wikidot.com）に対する統合テストが含まれています。
+This directory contains integration tests that run against an actual Wikidot server (ukwhatn-ci.wikidot.com).
 
-## 環境設定
+## Environment Setup
 
-### 必要な環境変数
+### Required Environment Variables
 
 ```bash
 export WIKIDOT_USERNAME=your_username
 export WIKIDOT_PASSWORD=your_password
 ```
 
-### テストサイト
+### Test Site
 
-- サイト名: `ukwhatn-ci.wikidot.com`
-- 要件: テストアカウントがサイトのメンバーであること
+- Site name: `ukwhatn-ci.wikidot.com`
+- Requirement: Test account must be a member of the site
 
-## テスト実行
+## Running Tests
 
 ```bash
-# 統合テストのみ実行
+# Run integration tests only
 cd /Users/yuki.c.watanabe/dev/scp/libs/wikidot-ts
 bun test tests/integration/
 
-# 特定のテストファイルを実行
+# Run a specific test file
 bun test tests/integration/page-lifecycle.test.ts
 
-# 全テスト（ユニット + 統合）
+# Run all tests (unit + integration)
 bun test
 ```
 
-## テストカバー範囲
+## Test Coverage
 
-| テストファイル | カバー機能 |
-|--------------|----------|
-| site.test.ts | サイト取得、ページ取得 |
-| page-lifecycle.test.ts | ページ作成、取得、編集、削除 |
-| page-tags.test.ts | タグ追加、変更、削除 |
-| page-meta.test.ts | メタ設定、取得、更新、削除 |
-| page-revision.test.ts | リビジョン履歴取得、最新リビジョン取得 |
-| page-votes.test.ts | 投票情報取得 |
-| page-discussion.test.ts | ディスカッション取得、投稿作成 |
-| forum-category.test.ts | フォーラムカテゴリ一覧、スレッド取得 |
-| user.test.ts | ユーザー検索、一括取得 |
-| pm.test.ts | 受信箱/送信箱取得、メッセージ確認 |
+| Test File | Covered Features |
+|-----------|------------------|
+| site.test.ts | Site retrieval, page retrieval |
+| page-lifecycle.test.ts | Page creation, retrieval, editing, deletion |
+| page-tags.test.ts | Tag addition, modification, deletion |
+| page-meta.test.ts | Meta setting, retrieval, update, deletion |
+| page-revision.test.ts | Revision history retrieval, latest revision retrieval |
+| page-votes.test.ts | Vote information retrieval |
+| page-discussion.test.ts | Discussion retrieval, post creation |
+| forum-category.test.ts | Forum category listing, thread retrieval |
+| user.test.ts | User search, bulk retrieval |
+| pm.test.ts | Inbox/outbox retrieval, message verification |
 
-## スキップ対象機能
+## Skipped Features
 
-以下の機能は統合テストからスキップされています:
+The following features are skipped in integration tests:
 
-### 1. サイト参加申請
-- 理由: テストサイトへの参加申請は手動承認が必要
-- 該当API: `site.application.*`
+### 1. Site Join Application
+- Reason: Site join applications require manual approval
+- Related API: `site.application.*`
 
-### 2. プライベートメッセージ送信
-- 理由: 実ユーザーへのメッセージ送信を避けるため
-- 該当API: `client.privateMessage.send()`
-- 備考: 取得のみテスト。事前にInbox/Outboxにメッセージを入れておくこと
+### 2. Private Message Sending
+- Reason: To avoid sending messages to real users
+- Related API: `client.privateMessage.send()`
+- Note: Only retrieval is tested. Messages must be pre-populated in Inbox/Outbox
 
-### 3. フォーラムカテゴリ/スレッド作成
-- 理由: フォーラム構造への永続的な変更を避けるため
-- 該当API: `site.forum.createThread()`
-- 備考: ページディスカッションへの投稿のみテスト
+### 3. Forum Category/Thread Creation
+- Reason: To avoid permanent changes to forum structure
+- Related API: `site.forum.createThread()`
+- Note: Only page discussion posts are tested
 
-### 4. メンバー招待
-- 理由: 実ユーザーへの招待を避けるため
-- 該当API: `site.member.invite()`
+### 4. Member Invitation
+- Reason: To avoid inviting real users
+- Related API: `site.member.invite()`
 
-## クリーンアップ戦略
+## Cleanup Strategy
 
-1. 各テストの`beforeAll`でテスト用ページを作成
-2. `afterAll`で作成したページを削除
-3. 削除失敗時はログ出力して続行
-4. ページ命名: `{prefix}-{timestamp}-{random6chars}` 形式で衝突を回避
+1. Create test pages in each test's `beforeAll`
+2. Delete created pages in `afterAll`
+3. Log and continue on deletion failure
+4. Page naming: `{prefix}-{timestamp}-{random6chars}` format to avoid collisions
 
-## 注意事項
+## Notes
 
-- 環境変数が未設定の場合、統合テストは自動的にスキップされます
-- テストは各ファイル内で順次実行されます（テスト間に依存関係がある場合があるため）
-- APIレート制限に注意してください
-- テスト実行後、クリーンアップに失敗したページが残る場合があります
-  - ページ名プレフィックス（`test-`）で識別可能
-  - 必要に応じて手動削除してください
+- Integration tests are automatically skipped if environment variables are not set
+- Tests are executed sequentially within each file (some tests may have dependencies)
+- Be aware of API rate limits
+- Pages may remain after test execution if cleanup fails
+  - Identifiable by page name prefix (`test-`)
+  - Delete manually if needed

--- a/tests/integration/forum-category.test.ts
+++ b/tests/integration/forum-category.test.ts
@@ -1,28 +1,28 @@
 /**
- * フォーラムカテゴリの統合テスト
+ * Forum category integration tests
  */
 import { describe, expect, test } from 'bun:test';
 import { getSite } from './helpers/client';
 import { shouldSkipIntegration } from './setup';
 
 describe.skipIf(shouldSkipIntegration())('Forum Category Integration Tests', () => {
-  test('1. フォーラムカテゴリ一覧取得', async () => {
+  test('1. Get forum category list', async () => {
     const site = await getSite();
     const result = await site.forum.getCategories();
     expect(result.isOk()).toBe(true);
 
     const categories = result.value!;
-    // カテゴリがなくても空のコレクションが返る
+    // Empty collection is returned even if no categories exist
     expect(Array.isArray(categories)).toBe(true);
   });
 
-  test('2. カテゴリプロパティ確認', async () => {
+  test('2. Verify category properties', async () => {
     const site = await getSite();
     const result = await site.forum.getCategories();
     expect(result.isOk()).toBe(true);
 
     const categories = result.value!;
-    // カテゴリがある場合はプロパティを確認
+    // Verify properties if categories exist
     if (categories.length > 0) {
       const category = categories[0];
       expect(category.id).toBeDefined();
@@ -31,13 +31,13 @@ describe.skipIf(shouldSkipIntegration())('Forum Category Integration Tests', () 
     }
   });
 
-  test('3. カテゴリのスレッド一覧取得', async () => {
+  test('3. Get thread list from category', async () => {
     const site = await getSite();
     const result = await site.forum.getCategories();
     expect(result.isOk()).toBe(true);
 
     const categories = result.value!;
-    // カテゴリがある場合はスレッドを取得
+    // Get threads if categories exist
     if (categories.length > 0) {
       const category = categories[0];
       const threadsResult = await category.getThreads();

--- a/tests/integration/helpers/cleanup.ts
+++ b/tests/integration/helpers/cleanup.ts
@@ -1,10 +1,10 @@
 /**
- * クリーンアップユーティリティ
+ * Cleanup utilities
  */
 import type { Site } from '../../../src';
 
 /**
- * ページを安全に削除
+ * Safely delete page
  */
 export async function safeDeletePage(site: Site, fullname: string): Promise<void> {
   try {
@@ -13,6 +13,6 @@ export async function safeDeletePage(site: Site, fullname: string): Promise<void
       await pageResult.value.destroy();
     }
   } catch {
-    // 削除失敗は無視（既に存在しない可能性）
+    // Ignore deletion failure (may not exist)
   }
 }

--- a/tests/integration/helpers/client.ts
+++ b/tests/integration/helpers/client.ts
@@ -1,5 +1,5 @@
 /**
- * クライアント作成ヘルパー
+ * Client creation helper
  */
 import { Client, type Site } from '../../../src';
 import { requireCredentials, TEST_CONFIG } from '../setup';
@@ -8,13 +8,13 @@ let cachedClient: Client | null = null;
 let cachedSite: Site | null = null;
 
 /**
- * 認証済みクライアントを取得（キャッシュ）
+ * Get authenticated client (cached)
  */
 export async function getClient(): Promise<Client> {
   if (cachedClient) return cachedClient;
 
   requireCredentials();
-  // requireCredentials()で検証済みなのでstring型として扱う
+  // Already validated by requireCredentials(), so treat as string type
   const username = TEST_CONFIG.username as string;
   const password = TEST_CONFIG.password as string;
   const result = await Client.create({
@@ -31,7 +31,7 @@ export async function getClient(): Promise<Client> {
 }
 
 /**
- * テストサイトを取得（キャッシュ）
+ * Get test site (cached)
  */
 export async function getSite(): Promise<Site> {
   if (cachedSite) return cachedSite;
@@ -48,7 +48,7 @@ export async function getSite(): Promise<Site> {
 }
 
 /**
- * テスト終了時のクリーンアップ
+ * Cleanup after test completion
  */
 export async function cleanup(): Promise<void> {
   if (cachedClient) {

--- a/tests/integration/helpers/page-name.ts
+++ b/tests/integration/helpers/page-name.ts
@@ -1,11 +1,11 @@
 /**
- * テスト用ランダムページ名生成
+ * Random page name generation for testing
  */
 
 /**
- * テスト用ランダムページ名を生成
- * フォーマット: {prefix}-{timestamp}-{random6chars}
- * 例: test-1703404800000-abc123
+ * Generate random page name for testing
+ * Format: {prefix}-{timestamp}-{random6chars}
+ * Example: test-1703404800000-abc123
  */
 export function generatePageName(prefix = 'test'): string {
   const timestamp = Date.now();

--- a/tests/integration/helpers/retry.ts
+++ b/tests/integration/helpers/retry.ts
@@ -1,18 +1,18 @@
 /**
- * リトライ付き検証ヘルパー
+ * Retry verification helper
  *
- * Wikidot APIのeventual consistencyを考慮し、
- * 期待する条件が満たされるまでリトライを行うためのヘルパー
+ * Helper for retrying until expected conditions are met,
+ * considering Wikidot API's eventual consistency
  */
 
 /**
- * 条件が満たされるまでリトライする
- * @param fn - 値を取得する関数
- * @param predicate - 条件を判定する関数
- * @param maxRetries - 最大リトライ回数（デフォルト: 10）
- * @param interval - リトライ間隔（ミリ秒、デフォルト: 2000）
- * @returns 条件を満たした値
- * @throws 条件を満たさないままリトライ上限に達した場合
+ * Retry until condition is met
+ * @param fn - Function to get value
+ * @param predicate - Function to check condition
+ * @param maxRetries - Maximum retry count (default: 10)
+ * @param interval - Retry interval in milliseconds (default: 2000)
+ * @returns Value that satisfies the condition
+ * @throws When retry limit reached without satisfying condition
  */
 export async function waitForCondition<T>(
   fn: () => Promise<T>,

--- a/tests/integration/page-lifecycle.test.ts
+++ b/tests/integration/page-lifecycle.test.ts
@@ -1,5 +1,5 @@
 /**
- * ページライフサイクル（作成→取得→編集→削除）の統合テスト
+ * Page lifecycle (create -> get -> edit -> delete) integration tests
  */
 import { afterAll, beforeAll, describe, expect, test } from 'bun:test';
 import type { Page } from '../../src';
@@ -17,13 +17,13 @@ describe.skipIf(shouldSkipIntegration())('Page Lifecycle Integration Tests', () 
   });
 
   afterAll(async () => {
-    // テスト失敗時のクリーンアップ
+    // Cleanup on test failure
     const site = await getSite();
     await safeDeletePage(site, pageName);
     await cleanup();
   });
 
-  test('1. ページ作成', async () => {
+  test('1. Create page', async () => {
     const site = await getSite();
 
     const createResult = await site.page.create(pageName, {
@@ -35,7 +35,7 @@ describe.skipIf(shouldSkipIntegration())('Page Lifecycle Integration Tests', () 
     expect(createResult.isOk()).toBe(true);
   });
 
-  test('2. 作成ページ取得', async () => {
+  test('2. Get created page', async () => {
     const site = await getSite();
 
     const pageResult = await site.page.get(pageName);
@@ -47,7 +47,7 @@ describe.skipIf(shouldSkipIntegration())('Page Lifecycle Integration Tests', () 
     expect(createdPage.title).toBe('Test Page');
   });
 
-  test('3. ページソース取得', async () => {
+  test('3. Get page source', async () => {
     const site = await getSite();
     const pageResult = await site.page.get(pageName);
     expect(pageResult.isOk()).toBe(true);
@@ -58,7 +58,7 @@ describe.skipIf(shouldSkipIntegration())('Page Lifecycle Integration Tests', () 
     expect(sourceResult.value?.wikiText).toBe('This is test content.');
   });
 
-  test('4. ページ編集', async () => {
+  test('4. Edit page', async () => {
     const site = await getSite();
     const pageResult = await site.page.get(pageName);
     expect(pageResult.isOk()).toBe(true);
@@ -72,7 +72,7 @@ describe.skipIf(shouldSkipIntegration())('Page Lifecycle Integration Tests', () 
 
     expect(editResult.isOk()).toBe(true);
 
-    // 再取得して確認
+    // Re-fetch and verify
     const updatedResult = await site.page.get(pageName);
     expect(updatedResult.isOk()).toBe(true);
     expect(updatedResult.value?.title).toBe('Updated Test Page');
@@ -82,7 +82,7 @@ describe.skipIf(shouldSkipIntegration())('Page Lifecycle Integration Tests', () 
     expect(sourceResult.value?.wikiText).toBe('Updated content.');
   });
 
-  test('5. ページ削除', async () => {
+  test('5. Delete page', async () => {
     const site = await getSite();
     const pageResult = await site.page.get(pageName);
     expect(pageResult.isOk()).toBe(true);
@@ -91,7 +91,7 @@ describe.skipIf(shouldSkipIntegration())('Page Lifecycle Integration Tests', () 
     const deleteResult = await page.destroy();
     expect(deleteResult.isOk()).toBe(true);
 
-    // NOTE: 削除確認はWikidotのeventual consistencyにより不安定なためスキップ
-    // destroy()の成功をもって削除完了とする（afterAllでクリーンアップも実行される）
+    // NOTE: Deletion verification skipped due to Wikidot's eventual consistency
+    // Successful destroy() is considered deletion complete (afterAll also runs cleanup)
   });
 });

--- a/tests/integration/page-meta.test.ts
+++ b/tests/integration/page-meta.test.ts
@@ -1,5 +1,5 @@
 /**
- * ページメタ操作の統合テスト
+ * Page meta operations integration tests
  */
 import { afterAll, beforeAll, describe, expect, test } from 'bun:test';
 import type { Page } from '../../src';
@@ -16,7 +16,7 @@ describe.skipIf(shouldSkipIntegration())('Page Meta Integration Tests', () => {
     pageName = generatePageName('meta');
     const site = await getSite();
 
-    // テスト用ページを作成
+    // Create test page
     await site.page.create(pageName, {
       title: 'Meta Test Page',
       source: 'Content for meta test.',
@@ -34,14 +34,14 @@ describe.skipIf(shouldSkipIntegration())('Page Meta Integration Tests', () => {
     await cleanup();
   });
 
-  test('1. メタ設定', async () => {
+  test('1. Set meta', async () => {
     expect(page).not.toBeNull();
 
     const result = await page!.setMeta('description', 'Test description');
     expect(result.isOk()).toBe(true);
   });
 
-  test('2. メタ取得', async () => {
+  test('2. Get meta', async () => {
     const site = await getSite();
     const pageResult = await site.page.get(pageName);
     expect(pageResult.isOk()).toBe(true);
@@ -56,7 +56,7 @@ describe.skipIf(shouldSkipIntegration())('Page Meta Integration Tests', () => {
     expect(descMeta?.content).toBe('Test description');
   });
 
-  test('3. メタ更新', async () => {
+  test('3. Update meta', async () => {
     const site = await getSite();
     const pageResult = await site.page.get(pageName);
     expect(pageResult.isOk()).toBe(true);
@@ -65,14 +65,14 @@ describe.skipIf(shouldSkipIntegration())('Page Meta Integration Tests', () => {
     const result = await currentPage.setMeta('description', 'Updated description');
     expect(result.isOk()).toBe(true);
 
-    // 確認
+    // Verify
     const metasResult = await currentPage.getMetas();
     expect(metasResult.isOk()).toBe(true);
     const descMeta = metasResult.value?.findByName('description');
     expect(descMeta?.content).toBe('Updated description');
   });
 
-  test('4. メタ削除', async () => {
+  test('4. Delete meta', async () => {
     const site = await getSite();
     const pageResult = await site.page.get(pageName);
     expect(pageResult.isOk()).toBe(true);
@@ -81,26 +81,26 @@ describe.skipIf(shouldSkipIntegration())('Page Meta Integration Tests', () => {
     const result = await currentPage.deleteMeta('description');
     expect(result.isOk()).toBe(true);
 
-    // 確認
+    // Verify
     const metasResult = await currentPage.getMetas();
     expect(metasResult.isOk()).toBe(true);
     const descMeta = metasResult.value?.findByName('description');
     expect(descMeta).toBeUndefined();
   });
 
-  test('5. 複数メタの設定', async () => {
+  test('5. Set multiple metas', async () => {
     const site = await getSite();
     const pageResult = await site.page.get(pageName);
     expect(pageResult.isOk()).toBe(true);
 
     const currentPage = pageResult.value!;
 
-    // 複数メタを設定
+    // Set multiple metas
     await currentPage.setMeta('description', 'Page description');
     await currentPage.setMeta('keywords', 'keyword1, keyword2');
     await currentPage.setMeta('author', 'Test Author');
 
-    // 確認
+    // Verify
     const metasResult = await currentPage.getMetas();
     expect(metasResult.isOk()).toBe(true);
     expect(metasResult.value?.findByName('description')?.content).toBe('Page description');

--- a/tests/integration/page-revision.test.ts
+++ b/tests/integration/page-revision.test.ts
@@ -1,5 +1,5 @@
 /**
- * ページリビジョン（編集履歴）の統合テスト
+ * Page revision (edit history) integration tests
  */
 import { afterAll, beforeAll, describe, expect, test } from 'bun:test';
 import type { Page } from '../../src';
@@ -16,7 +16,7 @@ describe.skipIf(shouldSkipIntegration())('Page Revision Integration Tests', () =
     pageName = generatePageName('revision');
     const site = await getSite();
 
-    // テスト用ページを作成
+    // Create test page
     await site.page.create(pageName, {
       title: 'Revision Test Page',
       source: 'Initial content.',
@@ -26,13 +26,13 @@ describe.skipIf(shouldSkipIntegration())('Page Revision Integration Tests', () =
     if (pageResult.isOk() && pageResult.value) {
       page = pageResult.value;
 
-      // 編集してリビジョンを作成
+      // Edit to create revision
       await page.edit({
         source: 'Updated content.',
         comment: 'First edit',
       });
     }
-  }, 30000); // タイムアウトを30秒に設定
+  }, 30000); // Set timeout to 30 seconds
 
   afterAll(async () => {
     const site = await getSite();
@@ -40,7 +40,7 @@ describe.skipIf(shouldSkipIntegration())('Page Revision Integration Tests', () =
     await cleanup();
   });
 
-  test('1. リビジョン一覧取得', async () => {
+  test('1. Get revision list', async () => {
     const site = await getSite();
     const pageResult = await site.page.get(pageName);
     expect(pageResult.isOk()).toBe(true);
@@ -51,11 +51,11 @@ describe.skipIf(shouldSkipIntegration())('Page Revision Integration Tests', () =
 
     const revisions = revisionsResult.value;
     expect(revisions).not.toBeNull();
-    // 作成 + 編集で少なくとも1つ以上のリビジョンがある
+    // At least 1 revision from creation + edit
     expect(revisions!.length).toBeGreaterThanOrEqual(1);
   });
 
-  test('2. リビジョンプロパティ確認', async () => {
+  test('2. Verify revision properties', async () => {
     const site = await getSite();
     const pageResult = await site.page.get(pageName);
     expect(pageResult.isOk()).toBe(true);
@@ -74,7 +74,7 @@ describe.skipIf(shouldSkipIntegration())('Page Revision Integration Tests', () =
     expect(latestRev.createdAt).toBeDefined();
   });
 
-  test('3. 最新リビジョン取得', async () => {
+  test('3. Get latest revision', async () => {
     const site = await getSite();
     const pageResult = await site.page.get(pageName);
     expect(pageResult.isOk()).toBe(true);

--- a/tests/integration/page-votes.test.ts
+++ b/tests/integration/page-votes.test.ts
@@ -1,12 +1,12 @@
 /**
- * ページ投票の統合テスト
+ * Page votes integration tests
  */
 import { describe, expect, test } from 'bun:test';
 import { getSite } from './helpers/client';
 import { shouldSkipIntegration } from './setup';
 
 describe.skipIf(shouldSkipIntegration())('Page Votes Integration Tests', () => {
-  test('1. 既存ページの投票情報取得', async () => {
+  test('1. Get existing page votes', async () => {
     const site = await getSite();
     const pageResult = await site.page.get('start');
     expect(pageResult.isOk()).toBe(true);
@@ -17,11 +17,11 @@ describe.skipIf(shouldSkipIntegration())('Page Votes Integration Tests', () => {
 
     const votes = votesResult.value;
     expect(votes).not.toBeNull();
-    // 投票がなくても空のコレクションが返る
+    // Empty collection is returned even if no votes exist
     expect(Array.isArray(votes)).toBe(true);
   });
 
-  test('2. 投票プロパティ確認', async () => {
+  test('2. Verify vote properties', async () => {
     const site = await getSite();
     const pageResult = await site.page.get('start');
     expect(pageResult.isOk()).toBe(true);
@@ -31,7 +31,7 @@ describe.skipIf(shouldSkipIntegration())('Page Votes Integration Tests', () => {
     expect(votesResult.isOk()).toBe(true);
 
     const votes = votesResult.value!;
-    // 投票がある場合はプロパティを確認
+    // Verify properties if votes exist
     if (votes.length > 0) {
       const vote = votes[0];
       expect(vote.page).toBeDefined();

--- a/tests/integration/pm.test.ts
+++ b/tests/integration/pm.test.ts
@@ -1,8 +1,8 @@
 /**
- * プライベートメッセージ取得の統合テスト
+ * Private message retrieval integration tests
  *
- * NOTE: メッセージ送信はスキップ。取得のみテスト。
- * 事前にInbox/Outboxにメッセージが入っていることを前提とする。
+ * NOTE: Message sending is skipped. Only retrieval is tested.
+ * Assumes messages exist in Inbox/Outbox beforehand.
  */
 import { afterAll, beforeAll, describe, expect, test } from 'bun:test';
 import type { Client } from '../../src';
@@ -20,18 +20,18 @@ describe.skipIf(shouldSkipIntegration())('Private Message Integration Tests', ()
     await cleanup();
   });
 
-  test('1. 受信箱取得', async () => {
+  test('1. Get inbox', async () => {
     const inboxResult = await client.privateMessage.inbox();
     expect(inboxResult.isOk()).toBe(true);
 
     const inbox = inboxResult.value!;
-    // メッセージ一覧を取得
+    // Get message list
     const messages = [...inbox];
-    // メッセージがあることを期待（事前にテスト用メッセージを入れておく）
-    expect(messages.length).toBeGreaterThanOrEqual(0); // 空でもテストは通す
+    // Expect messages (test messages should be prepared beforehand)
+    expect(messages.length).toBeGreaterThanOrEqual(0); // Test passes even if empty
   });
 
-  test('2. 送信箱取得', async () => {
+  test('2. Get sent box', async () => {
     const sentBoxResult = await client.privateMessage.sentBox();
     expect(sentBoxResult.isOk()).toBe(true);
 
@@ -40,7 +40,7 @@ describe.skipIf(shouldSkipIntegration())('Private Message Integration Tests', ()
     expect(messages.length).toBeGreaterThanOrEqual(0);
   });
 
-  test('3. 受信メッセージのプロパティ確認', async () => {
+  test('3. Verify received message properties', async () => {
     const inboxResult = await client.privateMessage.inbox();
     expect(inboxResult.isOk()).toBe(true);
 
@@ -54,7 +54,7 @@ describe.skipIf(shouldSkipIntegration())('Private Message Integration Tests', ()
 
     const message = messages[0];
 
-    // 基本プロパティ
+    // Basic properties
     expect(message.id).toBeDefined();
     expect(message.id).toBeGreaterThan(0);
     expect(message.subject).toBeDefined();
@@ -62,7 +62,7 @@ describe.skipIf(shouldSkipIntegration())('Private Message Integration Tests', ()
     expect(message.createdAt).toBeDefined();
   });
 
-  test('4. 送信メッセージのプロパティ確認', async () => {
+  test('4. Verify sent message properties', async () => {
     const sentBoxResult = await client.privateMessage.sentBox();
     expect(sentBoxResult.isOk()).toBe(true);
 
@@ -76,7 +76,7 @@ describe.skipIf(shouldSkipIntegration())('Private Message Integration Tests', ()
 
     const message = messages[0];
 
-    // 基本プロパティ
+    // Basic properties
     expect(message.id).toBeDefined();
     expect(message.id).toBeGreaterThan(0);
     expect(message.subject).toBeDefined();
@@ -84,7 +84,7 @@ describe.skipIf(shouldSkipIntegration())('Private Message Integration Tests', ()
     expect(message.createdAt).toBeDefined();
   });
 
-  test('5. IDでメッセージ取得', async () => {
+  test('5. Get message by ID', async () => {
     const inboxResult = await client.privateMessage.inbox();
     expect(inboxResult.isOk()).toBe(true);
 
@@ -96,7 +96,7 @@ describe.skipIf(shouldSkipIntegration())('Private Message Integration Tests', ()
       return;
     }
 
-    // 最初のメッセージのIDで再取得
+    // Re-fetch using first message's ID
     const messageId = messages[0].id;
     const messageResult = await client.privateMessage.get(messageId);
 

--- a/tests/integration/setup.ts
+++ b/tests/integration/setup.ts
@@ -1,9 +1,9 @@
 /**
- * 統合テスト用セットアップ
+ * Integration test setup
  */
 
 /**
- * テスト設定
+ * Test configuration
  */
 export const TEST_CONFIG = {
   siteUnixName: 'ukwhatn-ci',
@@ -12,15 +12,15 @@ export const TEST_CONFIG = {
 } as const;
 
 /**
- * 認証情報が設定されているかチェック
+ * Check if credentials are configured
  */
 export function hasCredentials(): boolean {
   return Boolean(TEST_CONFIG.username && TEST_CONFIG.password);
 }
 
 /**
- * 認証情報を必須としてチェック
- * @throws Error 認証情報が未設定の場合
+ * Require credentials to be set
+ * @throws Error if credentials are not configured
  */
 export function requireCredentials(): void {
   if (!hasCredentials()) {
@@ -29,7 +29,7 @@ export function requireCredentials(): void {
 }
 
 /**
- * 統合テストをスキップするべきかどうか
+ * Check if integration tests should be skipped
  */
 export function shouldSkipIntegration(): boolean {
   return !hasCredentials();

--- a/tests/integration/site.test.ts
+++ b/tests/integration/site.test.ts
@@ -1,5 +1,5 @@
 /**
- * サイト取得・ページ取得の統合テスト
+ * Site and page retrieval integration tests
  */
 import { afterAll, beforeAll, describe, expect, test } from 'bun:test';
 import { cleanup, getClient, getSite } from './helpers/client';
@@ -14,22 +14,22 @@ describe.skipIf(shouldSkipIntegration())('Site Integration Tests', () => {
     await cleanup();
   });
 
-  describe('Site取得', () => {
-    test('サイト取得', async () => {
+  describe('Site retrieval', () => {
+    test('Get site', async () => {
       const site = await getSite();
       expect(site.unixName).toBe('ukwhatn-ci');
       expect(site.id).toBeGreaterThan(0);
     });
 
-    test('サイトにタイトルがある', async () => {
+    test('Site has title', async () => {
       const site = await getSite();
       expect(site.title).toBeDefined();
       expect(site.title.length).toBeGreaterThan(0);
     });
   });
 
-  describe('Page取得', () => {
-    test('既存ページ取得（startページ）', async () => {
+  describe('Page retrieval', () => {
+    test('Get existing page (start page)', async () => {
       const site = await getSite();
       const pageResult = await site.page.get('start');
       expect(pageResult.isOk()).toBe(true);
@@ -37,14 +37,14 @@ describe.skipIf(shouldSkipIntegration())('Site Integration Tests', () => {
       expect(pageResult.value?.fullname).toBe('start');
     });
 
-    test('存在しないページ取得', async () => {
+    test('Get non-existent page', async () => {
       const site = await getSite();
       const pageResult = await site.page.get('nonexistent-page-12345678');
       expect(pageResult.isOk()).toBe(true);
       expect(pageResult.value).toBeNull();
     });
 
-    test('ページにプロパティがある', async () => {
+    test('Page has properties', async () => {
       const site = await getSite();
       const pageResult = await site.page.get('start');
       expect(pageResult.isOk()).toBe(true);
@@ -54,7 +54,7 @@ describe.skipIf(shouldSkipIntegration())('Site Integration Tests', () => {
       expect(page.title).toBeDefined();
       expect(page.createdAt).toBeDefined();
       expect(page.rating).toBeDefined();
-      // NOTE: 初期ページはrevisionsCountが0になる場合がある
+      // NOTE: Initial page may have revisionsCount of 0
       expect(page.revisionsCount).toBeGreaterThanOrEqual(0);
     });
   });

--- a/tests/integration/user.test.ts
+++ b/tests/integration/user.test.ts
@@ -1,12 +1,12 @@
 /**
- * ユーザー検索の統合テスト
+ * User search integration tests
  */
 import { describe, expect, test } from 'bun:test';
 import { getClient } from './helpers/client';
 import { shouldSkipIntegration } from './setup';
 
 describe.skipIf(shouldSkipIntegration())('User Search Integration Tests', () => {
-  test('1. ユーザー名でユーザー取得', async () => {
+  test('1. Get user by username', async () => {
     const client = await getClient();
     const result = await client.user.get('ukwhatn');
     expect(result.isOk()).toBe(true);
@@ -14,14 +14,14 @@ describe.skipIf(shouldSkipIntegration())('User Search Integration Tests', () => 
     expect(result.value!.name.toLowerCase()).toBe('ukwhatn');
   });
 
-  test('2. 存在しないユーザー取得', async () => {
+  test('2. Get non-existent user', async () => {
     const client = await getClient();
     const result = await client.user.get('nonexistent-user-12345678');
     expect(result.isOk()).toBe(true);
     expect(result.value).toBeNull();
   });
 
-  test('3. ユーザープロパティ確認', async () => {
+  test('3. Verify user properties', async () => {
     const client = await getClient();
     const result = await client.user.get('ukwhatn');
     expect(result.isOk()).toBe(true);
@@ -32,7 +32,7 @@ describe.skipIf(shouldSkipIntegration())('User Search Integration Tests', () => 
     expect(user.unixName).toBeDefined();
   });
 
-  test('4. 複数ユーザー一括取得', async () => {
+  test('4. Get multiple users at once', async () => {
     const client = await getClient();
     const result = await client.user.getMany(['ukwhatn']);
     expect(result.isOk()).toBe(true);

--- a/tests/mocks/amc-client.mock.ts
+++ b/tests/mocks/amc-client.mock.ts
@@ -1,7 +1,7 @@
 /**
  * AMCClient Mock
  *
- * AMCClientのモック実装（HTTPリクエストなし）
+ * Mock implementation for AMCClient (no HTTP requests)
  */
 
 import { err, ok, type ResultAsync } from 'neverthrow';
@@ -12,12 +12,12 @@ import type { AMCRequestBody, AMCResponse } from '../../src/connector/amc-types'
 import { TEST_AMC_CONFIG } from '../setup';
 
 /**
- * モックレスポンスハンドラー型
+ * Mock response handler type
  */
 export type MockResponseHandler = (body: AMCRequestBody) => AMCResponse | WikidotError;
 
 /**
- * AMCClient モック
+ * AMCClient mock
  */
 export class MockAMCClient {
   public readonly header: AMCHeader;
@@ -34,42 +34,42 @@ export class MockAMCClient {
   }
 
   /**
-   * モックレスポンスハンドラーを追加
+   * Add mock response handler
    */
   addResponseHandler(handler: MockResponseHandler): void {
     this.responseHandlers.push(handler);
   }
 
   /**
-   * レスポンスハンドラーをクリア
+   * Clear response handlers
    */
   clearResponseHandlers(): void {
     this.responseHandlers = [];
   }
 
   /**
-   * リクエスト履歴を取得
+   * Get request history
    */
   getRequestHistory(): AMCRequestBody[] {
     return [...this.requestHistory];
   }
 
   /**
-   * リクエスト履歴をクリア
+   * Clear request history
    */
   clearRequestHistory(): void {
     this.requestHistory = [];
   }
 
   /**
-   * SSL対応チェック（常にtrue）
+   * Check SSL support (always returns true)
    */
   checkSiteSSL(_siteName: string): ResultAsync<boolean, WikidotError> {
     return ok(true) as unknown as ResultAsync<boolean, WikidotError>;
   }
 
   /**
-   * モックリクエスト実行
+   * Execute mock request
    */
   request(
     bodies: AMCRequestBody[],
@@ -83,7 +83,7 @@ export class MockAMCClient {
     for (const body of bodies) {
       let response: AMCResponse | WikidotError | null = null;
 
-      // ハンドラーを順番に試す
+      // Try handlers in order
       for (const handler of this.responseHandlers) {
         const result = handler(body);
         if (result) {
@@ -92,7 +92,7 @@ export class MockAMCClient {
         }
       }
 
-      // ハンドラーが見つからない場合はデフォルトレスポンス
+      // Default response if no handler matches
       if (!response) {
         response = {
           status: 'ok',
@@ -101,7 +101,7 @@ export class MockAMCClient {
         };
       }
 
-      // エラーの場合
+      // If error
       if (response instanceof Error) {
         return err(response as WikidotError) as unknown as ResultAsync<AMCResponse[], WikidotError>;
       }
@@ -114,7 +114,7 @@ export class MockAMCClient {
 }
 
 /**
- * 成功レスポンスを作成
+ * Create success response
  */
 export function createOkResponse(body = ''): AMCResponse {
   return {
@@ -125,7 +125,7 @@ export function createOkResponse(body = ''): AMCResponse {
 }
 
 /**
- * エラーレスポンスを作成
+ * Create error response
  */
 export function createErrorResponse(status: string, message = ''): AMCResponse {
   return {
@@ -136,7 +136,7 @@ export function createErrorResponse(status: string, message = ''): AMCResponse {
 }
 
 /**
- * try_againレスポンスを作成
+ * Create try_again response
  */
 export function createTryAgainResponse(): AMCResponse {
   return {
@@ -146,7 +146,7 @@ export function createTryAgainResponse(): AMCResponse {
 }
 
 /**
- * no_permissionレスポンスを作成
+ * Create no_permission response
  */
 export function createNoPermissionResponse(): AMCResponse {
   return {

--- a/tests/mocks/http.mock.ts
+++ b/tests/mocks/http.mock.ts
@@ -1,11 +1,11 @@
 /**
  * HTTP Mock
  *
- * fetch/kyのモック実装
+ * Mock implementation for fetch/ky
  */
 
 /**
- * モックレスポンス定義
+ * Mock response definition
  */
 export interface MockResponse {
   status: number;
@@ -16,7 +16,7 @@ export interface MockResponse {
 }
 
 /**
- * モックリクエストマッチャー
+ * Mock request matcher
  */
 export interface MockRequestMatcher {
   url?: string | RegExp;
@@ -24,7 +24,7 @@ export interface MockRequestMatcher {
 }
 
 /**
- * モックエントリ
+ * Mock entry
  */
 interface MockEntry {
   matcher: MockRequestMatcher;
@@ -32,7 +32,7 @@ interface MockEntry {
 }
 
 /**
- * HTTPモッククラス
+ * HTTP mock class
  */
 export class HttpMock {
   private mocks: MockEntry[] = [];
@@ -44,35 +44,35 @@ export class HttpMock {
   }
 
   /**
-   * モックを追加
+   * Add mock
    */
   addMock(matcher: MockRequestMatcher, response: MockResponse): void {
     this.mocks.push({ matcher, response });
   }
 
   /**
-   * モックをクリア
+   * Clear mocks
    */
   clearMocks(): void {
     this.mocks = [];
   }
 
   /**
-   * リクエスト履歴を取得
+   * Get request history
    */
   getRequestHistory(): { url: string; options?: RequestInit }[] {
     return [...this.requestHistory];
   }
 
   /**
-   * リクエスト履歴をクリア
+   * Clear request history
    */
   clearRequestHistory(): void {
     this.requestHistory = [];
   }
 
   /**
-   * fetchをモックに置き換え
+   * Replace fetch with mock
    */
   install(): void {
     const self = this;
@@ -85,7 +85,7 @@ export class HttpMock {
 
       self.requestHistory.push({ url, options: init });
 
-      // マッチするモックを検索
+      // Search for matching mock
       for (const mock of self.mocks) {
         const urlMatch =
           !mock.matcher.url ||
@@ -101,20 +101,20 @@ export class HttpMock {
         }
       }
 
-      // デフォルト: 404
+      // Default: 404
       return self.createResponse({ status: 404, body: 'Not Found' });
     } as typeof fetch;
   }
 
   /**
-   * 元のfetchを復元
+   * Restore original fetch
    */
   restore(): void {
     globalThis.fetch = this.originalFetch;
   }
 
   /**
-   * Responseオブジェクトを作成
+   * Create Response object
    */
   private createResponse(mock: MockResponse): Response {
     const body = typeof mock.body === 'object' ? JSON.stringify(mock.body) : (mock.body ?? '');
@@ -133,7 +133,7 @@ export class HttpMock {
 }
 
 /**
- * HTTPモックインスタンスを作成して設定
+ * Create and configure HTTP mock instance
  */
 export function createHttpMock(): HttpMock {
   const mock = new HttpMock();

--- a/tests/setup.ts
+++ b/tests/setup.ts
@@ -1,13 +1,13 @@
 /**
  * Bun Test Setup
  *
- * テスト全体の共通セットアップを定義
+ * Define common setup for all tests
  */
 
 import type { AMCConfig } from '../src/connector/amc-config';
 
 /**
- * テスト用AMC設定（短いタイムアウト）
+ * Test AMC configuration (short timeout)
  */
 export const TEST_AMC_CONFIG: AMCConfig = {
   timeout: 5000,
@@ -19,7 +19,7 @@ export const TEST_AMC_CONFIG: AMCConfig = {
 };
 
 /**
- * テスト用認証情報
+ * Test credentials
  */
 export const TEST_CREDENTIALS = {
   username: 'test_user',
@@ -27,7 +27,7 @@ export const TEST_CREDENTIALS = {
 } as const;
 
 /**
- * テスト用サイトデータ
+ * Test site data
  */
 export const TEST_SITE_DATA = {
   id: 123456,
@@ -38,7 +38,7 @@ export const TEST_SITE_DATA = {
 } as const;
 
 /**
- * テスト用ページデータ
+ * Test page data
  */
 export const TEST_PAGE_DATA = {
   fullname: 'test-page',
@@ -57,7 +57,7 @@ export const TEST_PAGE_DATA = {
 } as const;
 
 /**
- * テスト用フォーラムカテゴリデータ
+ * Test forum category data
  */
 export const TEST_FORUM_CATEGORY_DATA = {
   id: 1001,
@@ -68,7 +68,7 @@ export const TEST_FORUM_CATEGORY_DATA = {
 } as const;
 
 /**
- * テスト用フォーラムスレッドデータ
+ * Test forum thread data
  */
 export const TEST_FORUM_THREAD_DATA = {
   id: 3001,
@@ -78,7 +78,7 @@ export const TEST_FORUM_THREAD_DATA = {
 } as const;
 
 /**
- * テスト用フォーラム投稿データ
+ * Test forum post data
  */
 export const TEST_FORUM_POST_DATA = {
   id: 5001,

--- a/tests/unit/common/errors.test.ts
+++ b/tests/unit/common/errors.test.ts
@@ -1,5 +1,5 @@
 /**
- * エラークラスのユニットテスト
+ * Error classes unit tests
  */
 import { describe, expect, test } from 'bun:test';
 import {
@@ -18,7 +18,7 @@ import {
 } from '../../../src/common/errors';
 
 describe('WikidotError', () => {
-  test('基本エラーを作成できる', () => {
+  test('Can create basic error', () => {
     const error = new WikidotError('test error');
 
     expect(error).toBeInstanceOf(Error);
@@ -29,7 +29,7 @@ describe('WikidotError', () => {
 });
 
 describe('UnexpectedError', () => {
-  test('予期しないエラーを作成できる', () => {
+  test('Can create unexpected error', () => {
     const error = new UnexpectedError('unexpected error');
 
     expect(error).toBeInstanceOf(WikidotError);
@@ -40,7 +40,7 @@ describe('UnexpectedError', () => {
 });
 
 describe('LoginRequiredError', () => {
-  test('ログイン必須エラーを作成できる', () => {
+  test('Can create login required error', () => {
     const error = new LoginRequiredError('login required');
 
     expect(error).toBeInstanceOf(WikidotError);
@@ -51,7 +51,7 @@ describe('LoginRequiredError', () => {
 });
 
 describe('AMCError', () => {
-  test('AMCエラーを作成できる', () => {
+  test('Can create AMC error', () => {
     const error = new AMCError('amc error');
 
     expect(error).toBeInstanceOf(WikidotError);
@@ -61,7 +61,7 @@ describe('AMCError', () => {
 });
 
 describe('AMCHttpError', () => {
-  test('HTTPステータスエラーを作成できる', () => {
+  test('Can create HTTP status error', () => {
     const error = new AMCHttpError('http error', 404);
 
     expect(error).toBeInstanceOf(AMCError);
@@ -70,7 +70,7 @@ describe('AMCHttpError', () => {
     expect(error.statusCode).toBe(404);
   });
 
-  test('ステータスコードを含むメッセージ', () => {
+  test('Message includes status code', () => {
     const error = new AMCHttpError('Not Found', 404);
 
     expect(error.statusCode).toBe(404);
@@ -78,7 +78,7 @@ describe('AMCHttpError', () => {
 });
 
 describe('WikidotStatusError', () => {
-  test('Wikidotステータスエラーを作成できる', () => {
+  test('Can create Wikidot status error', () => {
     const error = new WikidotStatusError('wikidot error', 'no_permission');
 
     expect(error).toBeInstanceOf(AMCError);
@@ -87,7 +87,7 @@ describe('WikidotStatusError', () => {
     expect(error.statusCode).toBe('no_permission');
   });
 
-  test('様々なステータスコード', () => {
+  test('Various status codes', () => {
     const tryAgain = new WikidotStatusError('retry', 'try_again');
     const notOk = new WikidotStatusError('failed', 'not_ok');
 
@@ -97,7 +97,7 @@ describe('WikidotStatusError', () => {
 });
 
 describe('ResponseDataError', () => {
-  test('レスポンスデータエラーを作成できる', () => {
+  test('Can create response data error', () => {
     const error = new ResponseDataError('invalid response');
 
     expect(error).toBeInstanceOf(AMCError);
@@ -107,7 +107,7 @@ describe('ResponseDataError', () => {
 });
 
 describe('NotFoundException', () => {
-  test('リソース未検出エラーを作成できる', () => {
+  test('Can create resource not found error', () => {
     const error = new NotFoundException('page not found');
 
     expect(error).toBeInstanceOf(WikidotError);
@@ -117,7 +117,7 @@ describe('NotFoundException', () => {
 });
 
 describe('TargetExistsError', () => {
-  test('リソース重複エラーを作成できる', () => {
+  test('Can create resource already exists error', () => {
     const error = new TargetExistsError('page already exists');
 
     expect(error).toBeInstanceOf(WikidotError);
@@ -127,7 +127,7 @@ describe('TargetExistsError', () => {
 });
 
 describe('TargetError', () => {
-  test('ターゲットエラーを作成できる', () => {
+  test('Can create target error', () => {
     const error = new TargetError('target error');
 
     expect(error).toBeInstanceOf(WikidotError);
@@ -137,7 +137,7 @@ describe('TargetError', () => {
 });
 
 describe('ForbiddenError', () => {
-  test('アクセス禁止エラーを作成できる', () => {
+  test('Can create access forbidden error', () => {
     const error = new ForbiddenError('access denied');
 
     expect(error).toBeInstanceOf(WikidotError);
@@ -147,7 +147,7 @@ describe('ForbiddenError', () => {
 });
 
 describe('NoElementError', () => {
-  test('要素未検出エラーを作成できる', () => {
+  test('Can create element not found error', () => {
     const error = new NoElementError('element not found');
 
     expect(error).toBeInstanceOf(WikidotError);
@@ -156,8 +156,8 @@ describe('NoElementError', () => {
   });
 });
 
-describe('エラー階層', () => {
-  test('すべてのエラーはWikidotErrorを継承している', () => {
+describe('Error hierarchy', () => {
+  test('All errors inherit from WikidotError', () => {
     const errors = [
       new UnexpectedError(''),
       new LoginRequiredError(''),
@@ -177,7 +177,7 @@ describe('エラー階層', () => {
     }
   });
 
-  test('AMC関連エラーはAMCErrorを継承している', () => {
+  test('AMC related errors inherit from AMCError', () => {
     const amcErrors = [
       new AMCHttpError('', 500),
       new WikidotStatusError('', 'error'),

--- a/tests/unit/common/types.test.ts
+++ b/tests/unit/common/types.test.ts
@@ -1,5 +1,5 @@
 /**
- * 共通型のユニットテスト
+ * Common types unit tests
  */
 import { describe, expect, test } from 'bun:test';
 import { UnexpectedError } from '../../../src/common/errors';
@@ -7,7 +7,7 @@ import { fromPromise, wdErr, wdErrAsync, wdOk, wdOkAsync } from '../../../src/co
 
 describe('WikidotResult', () => {
   describe('wdOk', () => {
-    test('成功結果を作成できる', () => {
+    test('Can create success result', () => {
       const result = wdOk('success');
 
       expect(result.isOk()).toBe(true);
@@ -15,7 +15,7 @@ describe('WikidotResult', () => {
       expect(result.value).toBe('success');
     });
 
-    test('様々な型の値を包める', () => {
+    test('Can wrap various value types', () => {
       const numResult = wdOk(42);
       const objResult = wdOk({ key: 'value' });
       const arrResult = wdOk([1, 2, 3]);
@@ -27,7 +27,7 @@ describe('WikidotResult', () => {
   });
 
   describe('wdErr', () => {
-    test('エラー結果を作成できる', () => {
+    test('Can create error result', () => {
       const error = new UnexpectedError('test error');
       const result = wdErr(error);
 
@@ -40,7 +40,7 @@ describe('WikidotResult', () => {
 
 describe('WikidotResultAsync', () => {
   describe('wdOkAsync', () => {
-    test('非同期成功結果を作成できる', async () => {
+    test('Can create async success result', async () => {
       const result = await wdOkAsync('async success');
 
       expect(result.isOk()).toBe(true);
@@ -49,7 +49,7 @@ describe('WikidotResultAsync', () => {
   });
 
   describe('wdErrAsync', () => {
-    test('非同期エラー結果を作成できる', async () => {
+    test('Can create async error result', async () => {
       const error = new UnexpectedError('async error');
       const result = await wdErrAsync(error);
 
@@ -59,7 +59,7 @@ describe('WikidotResultAsync', () => {
   });
 
   describe('fromPromise', () => {
-    test('成功するPromiseをラップできる', async () => {
+    test('Can wrap resolving promise', async () => {
       const promise = Promise.resolve('resolved');
       const result = await fromPromise(promise, (e) => new UnexpectedError(String(e)));
 
@@ -67,7 +67,7 @@ describe('WikidotResultAsync', () => {
       expect(result.value).toBe('resolved');
     });
 
-    test('失敗するPromiseをラップできる', async () => {
+    test('Can wrap rejecting promise', async () => {
       const promise = Promise.reject(new Error('rejected'));
       const result = await fromPromise(promise, (e) => new UnexpectedError(String(e)));
 
@@ -76,7 +76,7 @@ describe('WikidotResultAsync', () => {
       expect(result.error.message).toContain('rejected');
     });
 
-    test('エラーマッパーでカスタムエラーを返せる', async () => {
+    test('Can return custom error via error mapper', async () => {
       const promise = Promise.reject(new Error('original'));
       const result = await fromPromise(promise, () => new UnexpectedError('custom error message'));
 
@@ -86,8 +86,8 @@ describe('WikidotResultAsync', () => {
   });
 });
 
-describe('Result チェーン', () => {
-  test('mapで値を変換できる', async () => {
+describe('Result chaining', () => {
+  test('Can transform value with map', async () => {
     const result = await wdOkAsync(10);
     const mapped = result.map((v) => v * 2);
 
@@ -95,7 +95,7 @@ describe('Result チェーン', () => {
     expect(mapped.value).toBe(20);
   });
 
-  test('エラー時はmapをスキップする', async () => {
+  test('Skips map on error', async () => {
     const result = await wdErrAsync(new UnexpectedError('error'));
     const mapped = result.map((v: number) => v * 2);
 

--- a/tests/unit/connector/amc-client.test.ts
+++ b/tests/unit/connector/amc-client.test.ts
@@ -1,20 +1,20 @@
 /**
- * AMCClientのユニットテスト
+ * AMCClient unit tests
  */
 import { describe, expect, test } from 'bun:test';
 import { AMCClient, maskSensitiveData } from '../../../src/connector/amc-client';
 import { TEST_AMC_CONFIG } from '../../setup';
 
 describe('AMCClient', () => {
-  describe('コンストラクタ', () => {
-    test('デフォルト設定で作成できる', () => {
+  describe('Constructor', () => {
+    test('Can create with default settings', () => {
       const client = new AMCClient();
 
       expect(client.domain).toBe('wikidot.com');
       expect(client.header).toBeDefined();
     });
 
-    test('カスタム設定で作成できる', () => {
+    test('Can create with custom settings', () => {
       const client = new AMCClient(TEST_AMC_CONFIG, 'custom.wikidot.com');
 
       expect(client.domain).toBe('custom.wikidot.com');
@@ -23,8 +23,8 @@ describe('AMCClient', () => {
     });
   });
 
-  describe('設定', () => {
-    test('configが正しく設定される', () => {
+  describe('Configuration', () => {
+    test('Config is set correctly', () => {
       const client = new AMCClient(TEST_AMC_CONFIG);
 
       expect(client.config.timeout).toBe(5000);
@@ -36,8 +36,8 @@ describe('AMCClient', () => {
     });
   });
 
-  describe('ヘッダー', () => {
-    test('headerが初期化される', () => {
+  describe('Header', () => {
+    test('Header is initialized', () => {
       const client = new AMCClient();
 
       expect(client.header).toBeDefined();
@@ -47,7 +47,7 @@ describe('AMCClient', () => {
 });
 
 describe('maskSensitiveData', () => {
-  test('passwordがマスクされる', () => {
+  test('Password is masked', () => {
     const body = {
       moduleName: 'test',
       password: 'secret123',
@@ -59,7 +59,7 @@ describe('maskSensitiveData', () => {
     expect(result.moduleName).toBe('test');
   });
 
-  test('loginがマスクされる', () => {
+  test('Login is masked', () => {
     const body = {
       moduleName: 'test',
       login: 'username',
@@ -70,7 +70,7 @@ describe('maskSensitiveData', () => {
     expect(result.login).toBe('***MASKED***');
   });
 
-  test('WIKIDOT_SESSION_IDがマスクされる', () => {
+  test('WIKIDOT_SESSION_ID is masked', () => {
     const body = {
       moduleName: 'test',
       WIKIDOT_SESSION_ID: 'session123',
@@ -81,7 +81,7 @@ describe('maskSensitiveData', () => {
     expect(result.WIKIDOT_SESSION_ID).toBe('***MASKED***');
   });
 
-  test('wikidot_token7がマスクされる', () => {
+  test('wikidot_token7 is masked', () => {
     const body = {
       moduleName: 'test',
       wikidot_token7: 'token123',
@@ -92,7 +92,7 @@ describe('maskSensitiveData', () => {
     expect(result.wikidot_token7).toBe('***MASKED***');
   });
 
-  test('非機密データはマスクされない', () => {
+  test('Non-sensitive data is not masked', () => {
     const body = {
       moduleName: 'test',
       page_id: 12345,
@@ -106,7 +106,7 @@ describe('maskSensitiveData', () => {
     expect(result.action).toBe('someAction');
   });
 
-  test('複数の機密データが同時にマスクされる', () => {
+  test('Multiple sensitive data are masked at once', () => {
     const body = {
       moduleName: 'test',
       password: 'secret',

--- a/tests/unit/module/forum.test.ts
+++ b/tests/unit/module/forum.test.ts
@@ -1,5 +1,5 @@
 /**
- * Forumモジュールのユニットテスト
+ * Forum module unit tests
  */
 import { describe, expect, test } from 'bun:test';
 import type { Element } from 'domhandler';
@@ -17,7 +17,7 @@ import {
 } from '../../setup';
 
 /**
- * テスト用サイト作成
+ * Create test site
  */
 function createMockSite(): SiteRef {
   const _amcClient = new MockAMCClient();
@@ -40,7 +40,7 @@ function createMockSite(): SiteRef {
 }
 
 /**
- * テスト用スレッド参照作成
+ * Create test thread reference
  */
 function createMockThreadRef(site: SiteRef): ForumThreadRef {
   return {
@@ -50,7 +50,7 @@ function createMockThreadRef(site: SiteRef): ForumThreadRef {
 }
 
 /**
- * テスト用ユーザー作成
+ * Create test user
  */
 function createMockUser(name: string): User {
   const client = {
@@ -64,9 +64,9 @@ function createMockUser(name: string): User {
   });
 }
 
-describe('ForumCategoryデータクラス', () => {
-  describe('基本プロパティ', () => {
-    test('toString()が正しい文字列を返す', () => {
+describe('ForumCategory data class', () => {
+  describe('Basic properties', () => {
+    test('toString() returns correct string', () => {
       const site = createMockSite();
       const category = new ForumCategory({
         site: site as unknown as Parameters<typeof ForumCategory.prototype.constructor>[0]['site'],
@@ -84,7 +84,7 @@ describe('ForumCategoryデータクラス', () => {
       expect(result).toContain(`title=${TEST_FORUM_CATEGORY_DATA.title}`);
     });
 
-    test('idが正しく設定される', () => {
+    test('id is correctly set', () => {
       const site = createMockSite();
       const category = new ForumCategory({
         site: site as unknown as Parameters<typeof ForumCategory.prototype.constructor>[0]['site'],
@@ -98,7 +98,7 @@ describe('ForumCategoryデータクラス', () => {
       expect(category.id).toBe(999);
     });
 
-    test('titleが正しく設定される', () => {
+    test('title is correctly set', () => {
       const site = createMockSite();
       const category = new ForumCategory({
         site: site as unknown as Parameters<typeof ForumCategory.prototype.constructor>[0]['site'],
@@ -112,7 +112,7 @@ describe('ForumCategoryデータクラス', () => {
       expect(category.title).toBe('Custom Title');
     });
 
-    test('descriptionが正しく設定される', () => {
+    test('description is correctly set', () => {
       const site = createMockSite();
       const category = new ForumCategory({
         site: site as unknown as Parameters<typeof ForumCategory.prototype.constructor>[0]['site'],
@@ -126,7 +126,7 @@ describe('ForumCategoryデータクラス', () => {
       expect(category.description).toBe('Custom Description');
     });
 
-    test('threadsCountが正しく設定される', () => {
+    test('threadsCount is correctly set', () => {
       const site = createMockSite();
       const category = new ForumCategory({
         site: site as unknown as Parameters<typeof ForumCategory.prototype.constructor>[0]['site'],
@@ -140,7 +140,7 @@ describe('ForumCategoryデータクラス', () => {
       expect(category.threadsCount).toBe(50);
     });
 
-    test('postsCountが正しく設定される', () => {
+    test('postsCount is correctly set', () => {
       const site = createMockSite();
       const category = new ForumCategory({
         site: site as unknown as Parameters<typeof ForumCategory.prototype.constructor>[0]['site'],
@@ -156,9 +156,9 @@ describe('ForumCategoryデータクラス', () => {
   });
 });
 
-describe('ForumThreadデータクラス', () => {
-  describe('基本プロパティ', () => {
-    test('toString()が正しい文字列を返す', () => {
+describe('ForumThread data class', () => {
+  describe('Basic properties', () => {
+    test('toString() returns correct string', () => {
       const site = createMockSite();
       const thread = new ForumThread({
         site: site as unknown as Parameters<typeof ForumThread.prototype.constructor>[0]['site'],
@@ -177,7 +177,7 @@ describe('ForumThreadデータクラス', () => {
       expect(result).toContain(`title=${TEST_FORUM_THREAD_DATA.title}`);
     });
 
-    test('idが正しく設定される', () => {
+    test('id is correctly set', () => {
       const site = createMockSite();
       const thread = new ForumThread({
         site: site as unknown as Parameters<typeof ForumThread.prototype.constructor>[0]['site'],
@@ -192,7 +192,7 @@ describe('ForumThreadデータクラス', () => {
       expect(thread.id).toBe(5000);
     });
 
-    test('titleが正しく設定される', () => {
+    test('title is correctly set', () => {
       const site = createMockSite();
       const thread = new ForumThread({
         site: site as unknown as Parameters<typeof ForumThread.prototype.constructor>[0]['site'],
@@ -207,7 +207,7 @@ describe('ForumThreadデータクラス', () => {
       expect(thread.title).toBe('Custom Title');
     });
 
-    test('descriptionが正しく設定される', () => {
+    test('description is correctly set', () => {
       const site = createMockSite();
       const thread = new ForumThread({
         site: site as unknown as Parameters<typeof ForumThread.prototype.constructor>[0]['site'],
@@ -222,7 +222,7 @@ describe('ForumThreadデータクラス', () => {
       expect(thread.description).toBe('Custom Description');
     });
 
-    test('postCountが正しく設定される', () => {
+    test('postCount is correctly set', () => {
       const site = createMockSite();
       const thread = new ForumThread({
         site: site as unknown as Parameters<typeof ForumThread.prototype.constructor>[0]['site'],
@@ -239,9 +239,9 @@ describe('ForumThreadデータクラス', () => {
   });
 });
 
-describe('ForumPostデータクラス', () => {
-  describe('基本プロパティ', () => {
-    test('toString()が正しい文字列を返す', () => {
+describe('ForumPost data class', () => {
+  describe('Basic properties', () => {
+    test('toString() returns correct string', () => {
       const site = createMockSite();
       const threadRef = createMockThreadRef(site);
       const createdBy = createMockUser('TestUser');
@@ -266,7 +266,7 @@ describe('ForumPostデータクラス', () => {
       expect(result).toContain(`title=${TEST_FORUM_POST_DATA.title}`);
     });
 
-    test('idが正しく設定される', () => {
+    test('id is correctly set', () => {
       const site = createMockSite();
       const threadRef = createMockThreadRef(site);
       const createdBy = createMockUser('TestUser');
@@ -287,7 +287,7 @@ describe('ForumPostデータクラス', () => {
       expect(post.id).toBe(9999);
     });
 
-    test('titleが正しく設定される', () => {
+    test('title is correctly set', () => {
       const site = createMockSite();
       const threadRef = createMockThreadRef(site);
       const createdBy = createMockUser('TestUser');
@@ -308,7 +308,7 @@ describe('ForumPostデータクラス', () => {
       expect(post.title).toBe('Custom Title');
     });
 
-    test('textが正しく設定される', () => {
+    test('text is correctly set', () => {
       const site = createMockSite();
       const threadRef = createMockThreadRef(site);
       const createdBy = createMockUser('TestUser');
@@ -329,7 +329,7 @@ describe('ForumPostデータクラス', () => {
       expect(post.text).toBe('<p>Custom content</p>');
     });
 
-    test('parentIdがnullの場合', () => {
+    test('parentId when null', () => {
       const site = createMockSite();
       const threadRef = createMockThreadRef(site);
       const createdBy = createMockUser('TestUser');

--- a/tests/unit/module/page-file.test.ts
+++ b/tests/unit/module/page-file.test.ts
@@ -1,5 +1,5 @@
 /**
- * PageFileモジュールのユニットテスト
+ * PageFile module unit tests
  */
 import { describe, expect, test } from 'bun:test';
 import type { Page } from '../../../src/module/page/page';
@@ -9,7 +9,7 @@ import { MockAMCClient } from '../../mocks/amc-client.mock';
 import { TEST_SITE_DATA } from '../../setup';
 
 /**
- * テスト用サイト作成
+ * Create test site
  */
 function createMockSite(): SiteRef {
   const _amcClient = new MockAMCClient();
@@ -32,7 +32,7 @@ function createMockSite(): SiteRef {
 }
 
 /**
- * テスト用ページモック作成
+ * Create test page mock
  */
 function createMockPage(): Page {
   return {
@@ -44,7 +44,7 @@ function createMockPage(): Page {
 }
 
 /**
- * テスト用ファイル作成
+ * Create test file
  */
 function createTestFile(
   options: {
@@ -67,9 +67,9 @@ function createTestFile(
   });
 }
 
-describe('PageFileデータクラス', () => {
-  describe('基本プロパティ', () => {
-    test('toString()が正しい文字列を返す', () => {
+describe('PageFile data class', () => {
+  describe('Basic properties', () => {
+    test('toString() returns correct string', () => {
       const file = createTestFile();
 
       const result = file.toString();
@@ -79,31 +79,31 @@ describe('PageFileデータクラス', () => {
       expect(result).toContain('name=test-file.png');
     });
 
-    test('idが正しく設定される', () => {
+    test('id is correctly set', () => {
       const file = createTestFile({ id: 99999 });
 
       expect(file.id).toBe(99999);
     });
 
-    test('nameが正しく設定される', () => {
+    test('name is correctly set', () => {
       const file = createTestFile({ name: 'document.pdf' });
 
       expect(file.name).toBe('document.pdf');
     });
 
-    test('urlが正しく設定される', () => {
+    test('url is correctly set', () => {
       const file = createTestFile({ url: 'https://example.com/files/doc.pdf' });
 
       expect(file.url).toBe('https://example.com/files/doc.pdf');
     });
 
-    test('sizeが正しく設定される', () => {
+    test('size is correctly set', () => {
       const file = createTestFile({ size: 5000 });
 
       expect(file.size).toBe(5000);
     });
 
-    test('mimeTypeが正しく設定される', () => {
+    test('mimeType is correctly set', () => {
       const file = createTestFile({ mimeType: 'application/pdf' });
 
       expect(file.mimeType).toBe('application/pdf');
@@ -112,14 +112,14 @@ describe('PageFileデータクラス', () => {
 });
 
 describe('PageFileCollection', () => {
-  test('空のコレクションを作成できる', () => {
+  test('Can create empty collection', () => {
     const page = createMockPage();
     const collection = new PageFileCollection(page);
 
     expect(collection.length).toBe(0);
   });
 
-  test('ファイルを追加できる', () => {
+  test('Can add file', () => {
     const page = createMockPage();
     const collection = new PageFileCollection(page);
     const file = createTestFile({ page });
@@ -130,7 +130,7 @@ describe('PageFileCollection', () => {
     expect(collection[0]).toBe(file);
   });
 
-  test('複数ファイルで初期化できる', () => {
+  test('Can initialize with multiple files', () => {
     const page = createMockPage();
     const files = [
       createTestFile({ name: 'file1.png', page }),
@@ -142,7 +142,7 @@ describe('PageFileCollection', () => {
     expect(collection.length).toBe(3);
   });
 
-  test('名前でファイルを検索できる', () => {
+  test('Can find file by name', () => {
     const page = createMockPage();
     const files = [
       createTestFile({ name: 'image.png', page }),
@@ -156,7 +156,7 @@ describe('PageFileCollection', () => {
     expect(found?.name).toBe('document.pdf');
   });
 
-  test('MIMEタイプでファイルをフィルタできる', () => {
+  test('Can filter files by MIME type', () => {
     const page = createMockPage();
     const files = [
       createTestFile({ name: 'image1.png', mimeType: 'image/png', page }),

--- a/tests/unit/module/page-revision.test.ts
+++ b/tests/unit/module/page-revision.test.ts
@@ -1,5 +1,5 @@
 /**
- * PageRevisionモジュールのユニットテスト
+ * PageRevision module unit tests
  */
 import { describe, expect, test } from 'bun:test';
 import type { Page } from '../../../src/module/page/page';
@@ -10,7 +10,7 @@ import { MockAMCClient } from '../../mocks/amc-client.mock';
 import { TEST_SITE_DATA } from '../../setup';
 
 /**
- * テスト用サイト作成
+ * Create test site
  */
 function createMockSite(): SiteRef {
   const _amcClient = new MockAMCClient();
@@ -33,7 +33,7 @@ function createMockSite(): SiteRef {
 }
 
 /**
- * テスト用ページモック作成
+ * Create test page mock
  */
 function createMockPage(): Page {
   return {
@@ -45,7 +45,7 @@ function createMockPage(): Page {
 }
 
 /**
- * テスト用ユーザー作成
+ * Create test user
  */
 function createMockUser(name: string): User {
   const client = {
@@ -60,7 +60,7 @@ function createMockUser(name: string): User {
 }
 
 /**
- * テスト用リビジョン作成
+ * Create test revision
  */
 function createTestRevision(
   options: { id?: number; revNo?: number; comment?: string; page?: Page } = {}
@@ -77,9 +77,9 @@ function createTestRevision(
   });
 }
 
-describe('PageRevisionデータクラス', () => {
-  describe('基本プロパティ', () => {
-    test('toString()が正しい文字列を返す', () => {
+describe('PageRevision data class', () => {
+  describe('Basic properties', () => {
+    test('toString() returns correct string', () => {
       const revision = createTestRevision();
 
       const result = revision.toString();
@@ -89,32 +89,32 @@ describe('PageRevisionデータクラス', () => {
       expect(result).toContain('revNo=1');
     });
 
-    test('idが正しく設定される', () => {
+    test('id is correctly set', () => {
       const revision = createTestRevision({ id: 999999 });
 
       expect(revision.id).toBe(999999);
     });
 
-    test('revNoが正しく設定される', () => {
+    test('revNo is correctly set', () => {
       const revision = createTestRevision({ revNo: 5 });
 
       expect(revision.revNo).toBe(5);
     });
 
-    test('commentが正しく設定される', () => {
+    test('comment is correctly set', () => {
       const revision = createTestRevision({ comment: 'Updated content' });
 
       expect(revision.comment).toBe('Updated content');
     });
 
-    test('createdByが設定される', () => {
+    test('createdBy is set', () => {
       const revision = createTestRevision();
 
       expect(revision.createdBy).toBeDefined();
       expect(revision.createdBy.name).toBe('RevisionAuthor');
     });
 
-    test('createdAtが設定される', () => {
+    test('createdAt is set', () => {
       const revision = createTestRevision();
 
       expect(revision.createdAt).toBeInstanceOf(Date);
@@ -123,14 +123,14 @@ describe('PageRevisionデータクラス', () => {
 });
 
 describe('PageRevisionCollection', () => {
-  test('空のコレクションを作成できる', () => {
+  test('Can create empty collection', () => {
     const page = createMockPage();
     const collection = new PageRevisionCollection(page);
 
     expect(collection.length).toBe(0);
   });
 
-  test('リビジョンを追加できる', () => {
+  test('Can add revision', () => {
     const page = createMockPage();
     const collection = new PageRevisionCollection(page);
     const revision = createTestRevision({ page });
@@ -141,7 +141,7 @@ describe('PageRevisionCollection', () => {
     expect(collection[0]).toBe(revision);
   });
 
-  test('複数リビジョンで初期化できる', () => {
+  test('Can initialize with multiple revisions', () => {
     const page = createMockPage();
     const revisions = [
       createTestRevision({ revNo: 1, page }),
@@ -153,7 +153,7 @@ describe('PageRevisionCollection', () => {
     expect(collection.length).toBe(3);
   });
 
-  test('nullページでも作成できる', () => {
+  test('Can create with null page', () => {
     const collection = new PageRevisionCollection(null);
 
     expect(collection.length).toBe(0);

--- a/tests/unit/module/page-vote.test.ts
+++ b/tests/unit/module/page-vote.test.ts
@@ -1,5 +1,5 @@
 /**
- * PageVoteモジュールのユニットテスト
+ * PageVote module unit tests
  */
 import { describe, expect, test } from 'bun:test';
 import type { Page } from '../../../src/module/page/page';
@@ -10,7 +10,7 @@ import { MockAMCClient } from '../../mocks/amc-client.mock';
 import { TEST_SITE_DATA } from '../../setup';
 
 /**
- * モッククライアント作成
+ * Create mock client
  */
 function createMockClient(): ClientRef {
   return {
@@ -20,7 +20,7 @@ function createMockClient(): ClientRef {
 }
 
 /**
- * テスト用サイト作成
+ * Create test site
  */
 function createMockSite(): SiteRef {
   const _amcClient = new MockAMCClient();
@@ -40,7 +40,7 @@ function createMockSite(): SiteRef {
 }
 
 /**
- * テスト用ページモック作成
+ * Create test page mock
  */
 function createMockPage(): Page {
   return {
@@ -52,7 +52,7 @@ function createMockPage(): Page {
 }
 
 /**
- * テスト用ユーザー作成
+ * Create test user
  */
 function createMockUser(name: string): User {
   const client = createMockClient();
@@ -64,7 +64,7 @@ function createMockUser(name: string): User {
 }
 
 /**
- * テスト用投票作成
+ * Create test vote
  */
 function createTestVote(options: { value?: number; user?: User; page?: Page } = {}): PageVote {
   const user = options.user ?? createMockUser('Voter');
@@ -76,9 +76,9 @@ function createTestVote(options: { value?: number; user?: User; page?: Page } = 
   });
 }
 
-describe('PageVoteデータクラス', () => {
-  describe('基本プロパティ', () => {
-    test('toString()が正しい文字列を返す', () => {
+describe('PageVote data class', () => {
+  describe('Basic properties', () => {
+    test('toString() returns correct string', () => {
       const vote = createTestVote();
 
       const result = vote.toString();
@@ -88,19 +88,19 @@ describe('PageVoteデータクラス', () => {
       expect(result).toContain('value=1');
     });
 
-    test('valueが正の値の場合', () => {
+    test('Value is positive', () => {
       const vote = createTestVote({ value: 1 });
 
       expect(vote.value).toBe(1);
     });
 
-    test('valueが負の値の場合', () => {
+    test('Value is negative', () => {
       const vote = createTestVote({ value: -1 });
 
       expect(vote.value).toBe(-1);
     });
 
-    test('userが正しく設定される', () => {
+    test('User is correctly set', () => {
       const user = createMockUser('TestVoter');
       const vote = createTestVote({ user });
 
@@ -110,14 +110,14 @@ describe('PageVoteデータクラス', () => {
 });
 
 describe('PageVoteCollection', () => {
-  test('空のコレクションを作成できる', () => {
+  test('Can create empty collection', () => {
     const page = createMockPage();
     const collection = new PageVoteCollection(page);
 
     expect(collection.length).toBe(0);
   });
 
-  test('投票を追加できる', () => {
+  test('Can add vote', () => {
     const page = createMockPage();
     const collection = new PageVoteCollection(page);
     const vote = createTestVote({ page });
@@ -128,7 +128,7 @@ describe('PageVoteCollection', () => {
     expect(collection[0]).toBe(vote);
   });
 
-  test('複数投票で初期化できる', () => {
+  test('Can initialize with multiple votes', () => {
     const page = createMockPage();
     const votes = [
       createTestVote({ value: 1, page }),
@@ -140,7 +140,7 @@ describe('PageVoteCollection', () => {
     expect(collection.length).toBe(3);
   });
 
-  test('賛成票をカウントできる', () => {
+  test('Can count positive votes', () => {
     const page = createMockPage();
     const votes = [
       createTestVote({ value: 1, page }),
@@ -154,7 +154,7 @@ describe('PageVoteCollection', () => {
     expect(positiveVotes.length).toBe(2);
   });
 
-  test('反対票をカウントできる', () => {
+  test('Can count negative votes', () => {
     const page = createMockPage();
     const votes = [
       createTestVote({ value: 1, page }),

--- a/tests/unit/module/page.test.ts
+++ b/tests/unit/module/page.test.ts
@@ -1,5 +1,5 @@
 /**
- * Pageモジュールのユニットテスト
+ * Page module unit tests
  */
 import { describe, expect, test } from 'bun:test';
 import { Page, type PageData } from '../../../src/module/page/page';
@@ -8,7 +8,7 @@ import { MockAMCClient } from '../../mocks/amc-client.mock';
 import { TEST_PAGE_DATA, TEST_SITE_DATA } from '../../setup';
 
 /**
- * テスト用サイト作成
+ * Create test site
  */
 function createMockSite(): SiteRef {
   const _amcClient = new MockAMCClient();
@@ -38,7 +38,7 @@ function createMockSite(): SiteRef {
 }
 
 /**
- * テスト用ページ作成
+ * Create test page
  */
 function createTestPage(options: Partial<PageData> = {}): Page {
   const site = createMockSite();
@@ -66,9 +66,9 @@ function createTestPage(options: Partial<PageData> = {}): Page {
   });
 }
 
-describe('Pageデータクラス', () => {
-  describe('基本プロパティ', () => {
-    test('toString()が正しい文字列を返す', () => {
+describe('Page data class', () => {
+  describe('Basic properties', () => {
+    test('toString() returns correct string', () => {
       const page = createTestPage();
 
       const result = page.toString();
@@ -78,45 +78,45 @@ describe('Pageデータクラス', () => {
       expect(result).toContain('title=Test Page Title');
     });
 
-    test('fullnameが正しく設定される', () => {
+    test('fullname is correctly set', () => {
       const page = createTestPage({ fullname: 'scp-001' });
 
       expect(page.fullname).toBe('scp-001');
     });
 
-    test('nameが正しく設定される', () => {
+    test('name is correctly set', () => {
       const page = createTestPage({ name: 'scp-001' });
 
       expect(page.name).toBe('scp-001');
     });
 
-    test('categoryが正しく設定される', () => {
+    test('category is correctly set', () => {
       const page = createTestPage({ category: 'component' });
 
       expect(page.category).toBe('component');
     });
 
-    test('titleが正しく設定される', () => {
+    test('title is correctly set', () => {
       const page = createTestPage({ title: 'Custom Title' });
 
       expect(page.title).toBe('Custom Title');
     });
 
-    test('ratingが正しく設定される', () => {
+    test('rating is correctly set', () => {
       const page = createTestPage({ rating: 100 });
 
       expect(page.rating).toBe(100);
     });
 
-    test('tagsが正しく設定される', () => {
+    test('tags are correctly set', () => {
       const page = createTestPage({ tags: ['scp', 'euclid'] });
 
       expect(page.tags).toEqual(['scp', 'euclid']);
     });
   });
 
-  describe('URL生成', () => {
-    test('getUrl()がSSL対応サイトの正しいURLを返す', () => {
+  describe('URL generation', () => {
+    test('getUrl() returns correct URL for SSL-enabled site', () => {
       const page = createTestPage({ fullname: 'scp-001' });
 
       const url = page.getUrl();
@@ -125,20 +125,20 @@ describe('Pageデータクラス', () => {
     });
   });
 
-  describe('ページID', () => {
-    test('初期状態ではidがnull', () => {
+  describe('Page ID', () => {
+    test('id is null in initial state', () => {
       const page = createTestPage();
 
       expect(page.id).toBeNull();
     });
 
-    test('isIdAcquired()が初期状態でfalseを返す', () => {
+    test('isIdAcquired() returns false in initial state', () => {
       const page = createTestPage();
 
       expect(page.isIdAcquired()).toBe(false);
     });
 
-    test('idを設定するとisIdAcquired()がtrueを返す', () => {
+    test('isIdAcquired() returns true after setting id', () => {
       const page = createTestPage();
       page.id = 12345;
 
@@ -147,74 +147,74 @@ describe('Pageデータクラス', () => {
     });
   });
 
-  describe('統計情報', () => {
-    test('childrenCountが正しく設定される', () => {
+  describe('Statistics', () => {
+    test('childrenCount is correctly set', () => {
       const page = createTestPage({ childrenCount: 5 });
 
       expect(page.childrenCount).toBe(5);
     });
 
-    test('commentsCountが正しく設定される', () => {
+    test('commentsCount is correctly set', () => {
       const page = createTestPage({ commentsCount: 10 });
 
       expect(page.commentsCount).toBe(10);
     });
 
-    test('sizeが正しく設定される', () => {
+    test('size is correctly set', () => {
       const page = createTestPage({ size: 5000 });
 
       expect(page.size).toBe(5000);
     });
 
-    test('votesCountが正しく設定される', () => {
+    test('votesCount is correctly set', () => {
       const page = createTestPage({ votesCount: 25 });
 
       expect(page.votesCount).toBe(25);
     });
 
-    test('revisionsCountが正しく設定される', () => {
+    test('revisionsCount is correctly set', () => {
       const page = createTestPage({ revisionsCount: 10 });
 
       expect(page.revisionsCount).toBe(10);
     });
   });
 
-  describe('親ページ', () => {
-    test('parentFullnameがnullの場合', () => {
+  describe('Parent page', () => {
+    test('parentFullname when null', () => {
       const page = createTestPage({ parentFullname: null });
 
       expect(page.parentFullname).toBeNull();
     });
 
-    test('parentFullnameが設定される場合', () => {
+    test('parentFullname when set', () => {
       const page = createTestPage({ parentFullname: 'parent-page' });
 
       expect(page.parentFullname).toBe('parent-page');
     });
   });
 
-  describe('日時情報', () => {
-    test('createdAtが設定される', () => {
+  describe('Timestamps', () => {
+    test('createdAt is set', () => {
       const date = new Date('2024-01-01T00:00:00Z');
       const page = createTestPage({ createdAt: date });
 
       expect(page.createdAt).toEqual(date);
     });
 
-    test('updatedAtが設定される', () => {
+    test('updatedAt is set', () => {
       const date = new Date('2024-01-02T00:00:00Z');
       const page = createTestPage({ updatedAt: date });
 
       expect(page.updatedAt).toEqual(date);
     });
 
-    test('commentedAtがnullの場合', () => {
+    test('commentedAt when null', () => {
       const page = createTestPage({ commentedAt: null });
 
       expect(page.commentedAt).toBeNull();
     });
 
-    test('commentedAtが設定される場合', () => {
+    test('commentedAt when set', () => {
       const date = new Date('2024-01-03T00:00:00Z');
       const page = createTestPage({ commentedAt: date });
 

--- a/tests/unit/module/private-message.test.ts
+++ b/tests/unit/module/private-message.test.ts
@@ -1,5 +1,5 @@
 /**
- * PrivateMessageモジュールのユニットテスト
+ * PrivateMessage module unit tests
  */
 import { describe, expect, test } from 'bun:test';
 import type { Client } from '../../../src/module/client';
@@ -13,7 +13,7 @@ import type { ClientRef } from '../../../src/module/types';
 import { User } from '../../../src/module/user/user';
 
 /**
- * モッククライアント作成
+ * Create mock client
  */
 function createMockClient(): ClientRef {
   return {
@@ -23,7 +23,7 @@ function createMockClient(): ClientRef {
 }
 
 /**
- * テスト用ユーザー作成
+ * Create test user
  */
 function createMockUser(name: string): User {
   const client = createMockClient();
@@ -35,7 +35,7 @@ function createMockUser(name: string): User {
 }
 
 /**
- * テスト用メッセージ作成
+ * Create test message
  */
 function createTestMessage(
   options: { id?: number; subject?: string; body?: string; sender?: User; recipient?: User } = {}
@@ -55,9 +55,9 @@ function createTestMessage(
   });
 }
 
-describe('PrivateMessageデータクラス', () => {
-  describe('基本プロパティ', () => {
-    test('toString()が正しい文字列を返す', () => {
+describe('PrivateMessage data class', () => {
+  describe('Basic properties', () => {
+    test('toString() returns correct string', () => {
       const message = createTestMessage();
 
       const result = message.toString();
@@ -67,32 +67,32 @@ describe('PrivateMessageデータクラス', () => {
       expect(result).toContain('subject=Test Subject');
     });
 
-    test('idが正しく設定される', () => {
+    test('id is correctly set', () => {
       const message = createTestMessage({ id: 9999 });
 
       expect(message.id).toBe(9999);
     });
 
-    test('subjectが正しく設定される', () => {
+    test('subject is correctly set', () => {
       const message = createTestMessage({ subject: 'Custom Subject' });
 
       expect(message.subject).toBe('Custom Subject');
     });
 
-    test('bodyが正しく設定される', () => {
+    test('body is correctly set', () => {
       const message = createTestMessage({ body: 'Custom body text' });
 
       expect(message.body).toBe('Custom body text');
     });
 
-    test('senderが正しく設定される', () => {
+    test('sender is correctly set', () => {
       const sender = createMockUser('TestSender');
       const message = createTestMessage({ sender });
 
       expect(message.sender.name).toBe('TestSender');
     });
 
-    test('recipientが正しく設定される', () => {
+    test('recipient is correctly set', () => {
       const recipient = createMockUser('TestRecipient');
       const message = createTestMessage({ recipient });
 
@@ -102,14 +102,14 @@ describe('PrivateMessageデータクラス', () => {
 });
 
 describe('PrivateMessageCollection', () => {
-  test('空のコレクションを作成できる', () => {
+  test('Can create empty collection', () => {
     const client = createMockClient() as unknown as Client;
     const collection = new PrivateMessageCollection(client);
 
     expect(collection.length).toBe(0);
   });
 
-  test('メッセージを追加できる', () => {
+  test('Can add message', () => {
     const client = createMockClient() as unknown as Client;
     const collection = new PrivateMessageCollection(client);
     const message = createTestMessage();
@@ -120,7 +120,7 @@ describe('PrivateMessageCollection', () => {
     expect(collection[0]).toBe(message);
   });
 
-  test('複数メッセージで初期化できる', () => {
+  test('Can initialize with multiple messages', () => {
     const client = createMockClient() as unknown as Client;
     const messages = [
       createTestMessage({ id: 1 }),
@@ -134,7 +134,7 @@ describe('PrivateMessageCollection', () => {
 });
 
 describe('PrivateMessageInbox', () => {
-  test('Inboxを作成できる', () => {
+  test('Can create Inbox', () => {
     const client = createMockClient() as unknown as Client;
     const inbox = new PrivateMessageInbox(client);
 
@@ -142,7 +142,7 @@ describe('PrivateMessageInbox', () => {
     expect(inbox.length).toBe(0);
   });
 
-  test('メッセージ付きで初期化できる', () => {
+  test('Can initialize with messages', () => {
     const client = createMockClient() as unknown as Client;
     const messages = [createTestMessage({ id: 1 }), createTestMessage({ id: 2 })];
     const inbox = new PrivateMessageInbox(client, messages);
@@ -152,7 +152,7 @@ describe('PrivateMessageInbox', () => {
 });
 
 describe('PrivateMessageSentBox', () => {
-  test('SentBoxを作成できる', () => {
+  test('Can create SentBox', () => {
     const client = createMockClient() as unknown as Client;
     const sentBox = new PrivateMessageSentBox(client);
 
@@ -160,7 +160,7 @@ describe('PrivateMessageSentBox', () => {
     expect(sentBox.length).toBe(0);
   });
 
-  test('メッセージ付きで初期化できる', () => {
+  test('Can initialize with messages', () => {
     const client = createMockClient() as unknown as Client;
     const messages = [createTestMessage({ id: 1 }), createTestMessage({ id: 2 })];
     const sentBox = new PrivateMessageSentBox(client, messages);

--- a/tests/unit/module/search-pages-query.test.ts
+++ b/tests/unit/module/search-pages-query.test.ts
@@ -1,12 +1,12 @@
 /**
- * SearchPagesQueryのユニットテスト
+ * SearchPagesQuery unit tests
  */
 import { describe, expect, test } from 'bun:test';
 import { DEFAULT_MODULE_BODY, DEFAULT_PER_PAGE, SearchPagesQuery } from '../../../src/module/page';
 
 describe('SearchPagesQuery', () => {
-  describe('コンストラクタ', () => {
-    test('デフォルト値で初期化できる', () => {
+  describe('Constructor', () => {
+    test('Can initialize with default values', () => {
       const query = new SearchPagesQuery({});
 
       expect(query.category).toBe('*');
@@ -16,61 +16,61 @@ describe('SearchPagesQuery', () => {
       expect(query.offset).toBe(0);
     });
 
-    test('カテゴリを指定できる', () => {
+    test('Can specify category', () => {
       const query = new SearchPagesQuery({ category: '_default' });
 
       expect(query.category).toBe('_default');
     });
 
-    test('タグを指定できる（文字列）', () => {
+    test('Can specify tags (string)', () => {
       const query = new SearchPagesQuery({ tags: 'scp' });
 
       expect(query.tags).toBe('scp');
     });
 
-    test('タグを指定できる（配列）', () => {
+    test('Can specify tags (array)', () => {
       const query = new SearchPagesQuery({ tags: ['scp', 'safe'] });
 
       expect(query.tags).toEqual(['scp', 'safe']);
     });
 
-    test('作成者を指定できる', () => {
+    test('Can specify createdBy', () => {
       const query = new SearchPagesQuery({ createdBy: 'test-user' });
 
       expect(query.createdBy).toBe('test-user');
     });
 
-    test('レーティングを指定できる', () => {
+    test('Can specify rating', () => {
       const query = new SearchPagesQuery({ rating: '>10' });
 
       expect(query.rating).toBe('>10');
     });
 
-    test('親ページを指定できる', () => {
+    test('Can specify parent', () => {
       const query = new SearchPagesQuery({ parent: 'scp-001' });
 
       expect(query.parent).toBe('scp-001');
     });
 
-    test('ソート順を指定できる', () => {
+    test('Can specify order', () => {
       const query = new SearchPagesQuery({ order: 'rating desc' });
 
       expect(query.order).toBe('rating desc');
     });
 
-    test('オフセットを指定できる', () => {
+    test('Can specify offset', () => {
       const query = new SearchPagesQuery({ offset: 100 });
 
       expect(query.offset).toBe(100);
     });
 
-    test('リミットを指定できる', () => {
+    test('Can specify limit', () => {
       const query = new SearchPagesQuery({ limit: 50 });
 
       expect(query.limit).toBe(50);
     });
 
-    test('1ページあたりの件数を指定できる', () => {
+    test('Can specify perPage', () => {
       const query = new SearchPagesQuery({ perPage: 100 });
 
       expect(query.perPage).toBe(100);
@@ -78,7 +78,7 @@ describe('SearchPagesQuery', () => {
   });
 
   describe('asDict', () => {
-    test('デフォルトクエリの辞書を生成できる', () => {
+    test('Can generate dictionary from default query', () => {
       const query = new SearchPagesQuery({});
       const dict = query.asDict();
 
@@ -87,49 +87,49 @@ describe('SearchPagesQuery', () => {
       expect(dict.perPage).toBe(DEFAULT_PER_PAGE);
     });
 
-    test('タグ（文字列）を含む辞書を生成できる', () => {
+    test('Can generate dictionary with tags (string)', () => {
       const query = new SearchPagesQuery({ tags: 'scp' });
       const dict = query.asDict();
 
       expect(dict.tags).toBe('scp');
     });
 
-    test('タグ（配列）を含む辞書を生成できる', () => {
+    test('Can generate dictionary with tags (array)', () => {
       const query = new SearchPagesQuery({ tags: ['scp', 'safe'] });
       const dict = query.asDict();
 
       expect(dict.tags).toBe('scp safe');
     });
 
-    test('複数のタグをAND検索用に変換できる', () => {
+    test('Can convert multiple tags for AND search', () => {
       const query = new SearchPagesQuery({ tags: ['+scp', '+safe', '-euclid'] });
       const dict = query.asDict();
 
       expect(dict.tags).toBe('+scp +safe -euclid');
     });
 
-    test('親ページを含む辞書を生成できる', () => {
+    test('Can generate dictionary with parent', () => {
       const query = new SearchPagesQuery({ parent: 'scp-001' });
       const dict = query.asDict();
 
       expect(dict.parent).toBe('scp-001');
     });
 
-    test('レーティングを含む辞書を生成できる', () => {
+    test('Can generate dictionary with rating', () => {
       const query = new SearchPagesQuery({ rating: '>10' });
       const dict = query.asDict();
 
       expect(dict.rating).toBe('>10');
     });
 
-    test('オフセットを含む辞書を生成できる', () => {
+    test('Can generate dictionary with offset', () => {
       const query = new SearchPagesQuery({ offset: 100 });
       const dict = query.asDict();
 
       expect(dict.offset).toBe(100);
     });
 
-    test('リミットを含む辞書を生成できる', () => {
+    test('Can generate dictionary with limit', () => {
       const query = new SearchPagesQuery({ limit: 50 });
       const dict = query.asDict();
 
@@ -137,16 +137,16 @@ describe('SearchPagesQuery', () => {
     });
   });
 
-  describe('エッジケース', () => {
-    test('空のタグ配列はスペースで結合される', () => {
+  describe('Edge cases', () => {
+    test('Empty tag array is joined with space', () => {
       const query = new SearchPagesQuery({ tags: [] });
       const dict = query.asDict();
 
-      // 空配列は空文字列になる
+      // Empty array becomes empty string
       expect(dict.tags).toBe('');
     });
 
-    test('undefinedのパラメータは含まれない', () => {
+    test('Undefined parameters are not included', () => {
       const query = new SearchPagesQuery({});
       const dict = query.asDict();
 
@@ -157,12 +157,12 @@ describe('SearchPagesQuery', () => {
   });
 });
 
-describe('定数', () => {
-  test('DEFAULT_PER_PAGEが正しい値', () => {
+describe('Constants', () => {
+  test('DEFAULT_PER_PAGE has correct value', () => {
     expect(DEFAULT_PER_PAGE).toBe(250);
   });
 
-  test('DEFAULT_MODULE_BODYが正しいフォーマット', () => {
+  test('DEFAULT_MODULE_BODY has correct format', () => {
     expect(DEFAULT_MODULE_BODY).toContain('fullname');
     expect(DEFAULT_MODULE_BODY).toContain('name');
     expect(DEFAULT_MODULE_BODY).toContain('category');

--- a/tests/unit/module/site-application.test.ts
+++ b/tests/unit/module/site-application.test.ts
@@ -1,5 +1,5 @@
 /**
- * SiteApplicationモジュールのユニットテスト
+ * SiteApplication module unit tests
  */
 import { describe, expect, test } from 'bun:test';
 import { SiteApplication } from '../../../src/module/site/site-application';
@@ -9,7 +9,7 @@ import { MockAMCClient } from '../../mocks/amc-client.mock';
 import { TEST_SITE_DATA } from '../../setup';
 
 /**
- * モッククライアント作成
+ * Create mock client
  */
 function createMockClient(): ClientRef {
   return {
@@ -19,7 +19,7 @@ function createMockClient(): ClientRef {
 }
 
 /**
- * テスト用サイト作成
+ * Create test site
  */
 function createMockSite(): SiteRef {
   const _amcClient = new MockAMCClient();
@@ -39,7 +39,7 @@ function createMockSite(): SiteRef {
 }
 
 /**
- * テスト用ユーザー作成
+ * Create test user
  */
 function createMockUser(name: string): User {
   const client = createMockClient();
@@ -51,7 +51,7 @@ function createMockUser(name: string): User {
 }
 
 /**
- * テスト用申請作成
+ * Create test application
  */
 function createTestApplication(options: { user?: User; text?: string } = {}): SiteApplication {
   const site = createMockSite();
@@ -63,9 +63,9 @@ function createTestApplication(options: { user?: User; text?: string } = {}): Si
   });
 }
 
-describe('SiteApplicationデータクラス', () => {
-  describe('基本プロパティ', () => {
-    test('toString()が正しい文字列を返す', () => {
+describe('SiteApplication data class', () => {
+  describe('Basic properties', () => {
+    test('toString() returns correct string', () => {
       const application = createTestApplication();
 
       const result = application.toString();
@@ -74,20 +74,20 @@ describe('SiteApplicationデータクラス', () => {
       expect(result).toContain('user=Applicant');
     });
 
-    test('userが正しく設定される', () => {
+    test('user is correctly set', () => {
       const user = createMockUser('CustomApplicant');
       const application = createTestApplication({ user });
 
       expect(application.user.name).toBe('CustomApplicant');
     });
 
-    test('textが正しく設定される', () => {
+    test('text is correctly set', () => {
       const application = createTestApplication({ text: 'Custom application text' });
 
       expect(application.text).toBe('Custom application text');
     });
 
-    test('siteが正しく設定される', () => {
+    test('site is correctly set', () => {
       const application = createTestApplication();
 
       expect(application.site.unixName).toBe(TEST_SITE_DATA.unixName);

--- a/tests/unit/module/site-member.test.ts
+++ b/tests/unit/module/site-member.test.ts
@@ -1,5 +1,5 @@
 /**
- * SiteMemberモジュールのユニットテスト
+ * SiteMember module unit tests
  */
 import { describe, expect, test } from 'bun:test';
 import { SiteMember } from '../../../src/module/site/site-member';
@@ -9,7 +9,7 @@ import { MockAMCClient } from '../../mocks/amc-client.mock';
 import { TEST_SITE_DATA } from '../../setup';
 
 /**
- * モッククライアント作成
+ * Create mock client
  */
 function createMockClient(): ClientRef {
   return {
@@ -19,7 +19,7 @@ function createMockClient(): ClientRef {
 }
 
 /**
- * テスト用サイト作成
+ * Create test site
  */
 function createMockSite(): SiteRef {
   const _amcClient = new MockAMCClient();
@@ -39,7 +39,7 @@ function createMockSite(): SiteRef {
 }
 
 /**
- * テスト用ユーザー作成
+ * Create test user
  */
 function createMockUser(name: string): User {
   const client = createMockClient();
@@ -51,7 +51,7 @@ function createMockUser(name: string): User {
 }
 
 /**
- * テスト用メンバー作成
+ * Create test member
  */
 function createTestMember(
   options: { user?: User; joinedAt?: Date; role?: string } = {}
@@ -65,9 +65,9 @@ function createTestMember(
   });
 }
 
-describe('SiteMemberデータクラス', () => {
-  describe('基本プロパティ', () => {
-    test('toString()が正しい文字列を返す', () => {
+describe('SiteMember data class', () => {
+  describe('Basic properties', () => {
+    test('toString() returns correct string', () => {
       const member = createTestMember();
 
       const result = member.toString();
@@ -76,14 +76,14 @@ describe('SiteMemberデータクラス', () => {
       expect(result).toContain('user=TestMember');
     });
 
-    test('userが正しく設定される', () => {
+    test('user is correctly set', () => {
       const user = createMockUser('CustomUser');
       const member = createTestMember({ user });
 
       expect(member.user.name).toBe('CustomUser');
     });
 
-    test('joinedAtが正しく設定される', () => {
+    test('joinedAt is correctly set', () => {
       const date = new Date('2024-01-01T00:00:00Z');
       const member = createTestMember({ joinedAt: date });
 

--- a/tests/unit/module/site.test.ts
+++ b/tests/unit/module/site.test.ts
@@ -1,5 +1,5 @@
 /**
- * Siteモジュールのユニットテスト
+ * Site module unit tests
  */
 import { describe, expect, test } from 'bun:test';
 import { Site } from '../../../src/module/site/site';
@@ -7,7 +7,7 @@ import type { ClientRef } from '../../../src/module/types';
 import { MockAMCClient } from '../../mocks/amc-client.mock';
 
 /**
- * モッククライアント作成
+ * Create mock client
  */
 function createMockClient(): ClientRef & { amcClient: MockAMCClient } {
   const amcClient = new MockAMCClient();
@@ -19,7 +19,7 @@ function createMockClient(): ClientRef & { amcClient: MockAMCClient } {
 }
 
 /**
- * テスト用サイト作成
+ * Create test site
  */
 function createTestSite(
   options: Partial<{
@@ -40,9 +40,9 @@ function createTestSite(
   });
 }
 
-describe('Siteデータクラス', () => {
-  describe('基本プロパティ', () => {
-    test('toString()が正しい文字列を返す', () => {
+describe('Site data class', () => {
+  describe('Basic properties', () => {
+    test('toString() returns correct string', () => {
       const site = createTestSite();
 
       const result = site.toString();
@@ -53,63 +53,63 @@ describe('Siteデータクラス', () => {
       expect(result).toContain('unixName=test-site');
     });
 
-    test('SSL対応サイトのURLはhttps', () => {
+    test('SSL-enabled site URL uses https', () => {
       const site = createTestSite({ sslSupported: true });
 
       expect(site.getBaseUrl()).toBe('https://test-site.wikidot.com');
     });
 
-    test('SSL非対応サイトのURLはhttp', () => {
+    test('Non-SSL site URL uses http', () => {
       const site = createTestSite({ sslSupported: false });
 
       expect(site.getBaseUrl()).toBe('http://test-site.wikidot.com');
     });
 
-    test('idが正しく設定される', () => {
+    test('id is correctly set', () => {
       const site = createTestSite({ id: 999 });
 
       expect(site.id).toBe(999);
     });
 
-    test('titleが正しく設定される', () => {
+    test('title is correctly set', () => {
       const site = createTestSite({ title: 'Custom Title' });
 
       expect(site.title).toBe('Custom Title');
     });
 
-    test('unixNameが正しく設定される', () => {
+    test('unixName is correctly set', () => {
       const site = createTestSite({ unixName: 'custom-site' });
 
       expect(site.unixName).toBe('custom-site');
     });
 
-    test('domainが正しく設定される', () => {
+    test('domain is correctly set', () => {
       const site = createTestSite({ domain: 'custom.wikidot.com' });
 
       expect(site.domain).toBe('custom.wikidot.com');
     });
   });
 
-  describe('アクセサ', () => {
-    test('pagesアクセサが存在する', () => {
+  describe('Accessors', () => {
+    test('pages accessor exists', () => {
       const site = createTestSite();
 
       expect(site.pages).toBeDefined();
     });
 
-    test('pageアクセサが存在する', () => {
+    test('page accessor exists', () => {
       const site = createTestSite();
 
       expect(site.page).toBeDefined();
     });
 
-    test('forumアクセサが存在する', () => {
+    test('forum accessor exists', () => {
       const site = createTestSite();
 
       expect(site.forum).toBeDefined();
     });
 
-    test('memberアクセサが存在する', () => {
+    test('member accessor exists', () => {
       const site = createTestSite();
 
       expect(site.member).toBeDefined();

--- a/tests/unit/module/types.test.ts
+++ b/tests/unit/module/types.test.ts
@@ -1,5 +1,5 @@
 /**
- * 共有型定義のテスト
+ * Shared type definitions tests
  */
 import { describe, expect, test } from 'bun:test';
 import { wdOkAsync } from '../../../src/common/types';
@@ -12,10 +12,10 @@ import type {
   SiteRef,
 } from '../../../src/module/types';
 
-describe('共有型定義', () => {
+describe('Shared type definitions', () => {
   describe('ClientRef', () => {
-    test('必須プロパティが定義されている', () => {
-      // 型のテスト用のモックオブジェクト
+    test('Required properties are defined', () => {
+      // Mock object for type testing
       const mockClient: ClientRef = {
         requireLogin: () => ({ isErr: () => false }),
         isLoggedIn: () => true,
@@ -27,7 +27,7 @@ describe('共有型定義', () => {
   });
 
   describe('SiteRef', () => {
-    test('必須プロパティが定義されている', () => {
+    test('Required properties are defined', () => {
       const mockSite: SiteRef = {
         id: 123456,
         unixName: 'test-site',
@@ -49,7 +49,7 @@ describe('共有型定義', () => {
   });
 
   describe('ForumCategoryRef', () => {
-    test('必須プロパティが定義されている', () => {
+    test('Required properties are defined', () => {
       const mockCategory: ForumCategoryRef = {
         id: 1,
         title: 'Test Category',
@@ -62,7 +62,7 @@ describe('共有型定義', () => {
   });
 
   describe('ForumThreadRef', () => {
-    test('必須プロパティが定義されている', () => {
+    test('Required properties are defined', () => {
       const mockThread: ForumThreadRef = {
         id: 100,
         title: 'Test Thread',
@@ -74,7 +74,7 @@ describe('共有型定義', () => {
       expect(mockThread.title).toBe('Test Thread');
     });
 
-    test('categoryはnullまたはForumCategoryRefを持てる', () => {
+    test('category can be null or ForumCategoryRef', () => {
       const threadWithoutCategory: ForumThreadRef = {
         id: 100,
         title: 'Test Thread',
@@ -99,7 +99,7 @@ describe('共有型定義', () => {
   });
 
   describe('PageRef', () => {
-    test('必須プロパティが定義されている', () => {
+    test('Required properties are defined', () => {
       const mockPage: PageRef = {
         id: 12345,
         fullname: 'scp-001',
@@ -114,7 +114,7 @@ describe('共有型定義', () => {
       expect(mockPage.category).toBe('_default');
     });
 
-    test('idはnullを持てる', () => {
+    test('id can be null', () => {
       const pageWithoutId: PageRef = {
         id: null,
         fullname: 'new-page',

--- a/tests/unit/module/user.test.ts
+++ b/tests/unit/module/user.test.ts
@@ -1,5 +1,5 @@
 /**
- * Userモジュールのユニットテスト
+ * User module unit tests
  */
 import { describe, expect, test } from 'bun:test';
 import type { ClientRef } from '../../../src/module/types';
@@ -10,7 +10,7 @@ import { User } from '../../../src/module/user/user';
 import { WikidotUser } from '../../../src/module/user/wikidot-user';
 
 /**
- * モッククライアント作成
+ * Create mock client
  */
 function createMockClient(): ClientRef {
   return {
@@ -19,9 +19,9 @@ function createMockClient(): ClientRef {
   };
 }
 
-describe('Userデータクラス', () => {
+describe('User data class', () => {
   describe('User', () => {
-    test('toString()が正しい文字列を返す', () => {
+    test('toString() returns correct string', () => {
       const client = createMockClient();
       const user = new User(client, {
         id: 12345,
@@ -37,7 +37,7 @@ describe('Userデータクラス', () => {
       expect(result).toContain('name=test-user');
     });
 
-    test('userTypeが"user"である', () => {
+    test('userType is "user"', () => {
       const client = createMockClient();
       const user = new User(client, {
         id: 12345,
@@ -48,7 +48,7 @@ describe('Userデータクラス', () => {
       expect(user.userType).toBe('user');
     });
 
-    test('isUser()がtrueを返す', () => {
+    test('isUser() returns true', () => {
       const client = createMockClient();
       const user = new User(client, {
         id: 12345,
@@ -63,7 +63,7 @@ describe('Userデータクラス', () => {
       expect(user.isWikidotUser()).toBe(false);
     });
 
-    test('avatarUrlが設定される', () => {
+    test('avatarUrl is set', () => {
       const client = createMockClient();
       const user = new User(client, {
         id: 12345,
@@ -75,7 +75,7 @@ describe('Userデータクラス', () => {
       expect(user.avatarUrl).toBe('http://example.com/avatar.png');
     });
 
-    test('avatarUrlが未指定の場合デフォルト値が設定される', () => {
+    test('avatarUrl has default value when not specified', () => {
       const client = createMockClient();
       const user = new User(client, {
         id: 12345,
@@ -88,7 +88,7 @@ describe('Userデータクラス', () => {
   });
 
   describe('DeletedUser', () => {
-    test('デフォルト値が正しい', () => {
+    test('Default values are correct', () => {
       const client = createMockClient();
       const user = new DeletedUser(client, 99999);
 
@@ -98,14 +98,14 @@ describe('Userデータクラス', () => {
       expect(user.ip).toBeNull();
     });
 
-    test('userTypeが"deleted"である', () => {
+    test('userType is "deleted"', () => {
       const client = createMockClient();
       const user = new DeletedUser(client, 99999);
 
       expect(user.userType).toBe('deleted');
     });
 
-    test('isDeletedUser()がtrueを返す', () => {
+    test('isDeletedUser() returns true', () => {
       const client = createMockClient();
       const user = new DeletedUser(client, 99999);
 
@@ -116,7 +116,7 @@ describe('Userデータクラス', () => {
       expect(user.isWikidotUser()).toBe(false);
     });
 
-    test('toString()が正しい文字列を返す', () => {
+    test('toString() returns correct string', () => {
       const client = createMockClient();
       const user = new DeletedUser(client, 99999);
 
@@ -128,7 +128,7 @@ describe('Userデータクラス', () => {
   });
 
   describe('AnonymousUser', () => {
-    test('デフォルト値が正しい', () => {
+    test('Default values are correct', () => {
       const client = createMockClient();
       const user = new AnonymousUser(client, '192.168.1.1');
 
@@ -139,14 +139,14 @@ describe('Userデータクラス', () => {
       expect(user.ip).toBe('192.168.1.1');
     });
 
-    test('userTypeが"anonymous"である', () => {
+    test('userType is "anonymous"', () => {
       const client = createMockClient();
       const user = new AnonymousUser(client, '192.168.1.1');
 
       expect(user.userType).toBe('anonymous');
     });
 
-    test('isAnonymousUser()がtrueを返す', () => {
+    test('isAnonymousUser() returns true', () => {
       const client = createMockClient();
       const user = new AnonymousUser(client, '192.168.1.1');
 
@@ -157,7 +157,7 @@ describe('Userデータクラス', () => {
       expect(user.isWikidotUser()).toBe(false);
     });
 
-    test('toString()が正しい文字列を返す', () => {
+    test('toString() returns correct string', () => {
       const client = createMockClient();
       const user = new AnonymousUser(client, '192.168.1.1');
 
@@ -169,7 +169,7 @@ describe('Userデータクラス', () => {
   });
 
   describe('GuestUser', () => {
-    test('デフォルト値が正しい', () => {
+    test('Default values are correct', () => {
       const client = createMockClient();
       const user = new GuestUser(client, 'Guest Name', 'http://gravatar.com/avatar/abc');
 
@@ -180,14 +180,14 @@ describe('Userデータクラス', () => {
       expect(user.ip).toBeNull();
     });
 
-    test('userTypeが"guest"である', () => {
+    test('userType is "guest"', () => {
       const client = createMockClient();
       const user = new GuestUser(client, 'Guest Name', 'http://gravatar.com/avatar/abc');
 
       expect(user.userType).toBe('guest');
     });
 
-    test('isGuestUser()がtrueを返す', () => {
+    test('isGuestUser() returns true', () => {
       const client = createMockClient();
       const user = new GuestUser(client, 'Guest Name', 'http://gravatar.com/avatar/abc');
 
@@ -198,7 +198,7 @@ describe('Userデータクラス', () => {
       expect(user.isWikidotUser()).toBe(false);
     });
 
-    test('toString()が正しい文字列を返す', () => {
+    test('toString() returns correct string', () => {
       const client = createMockClient();
       const user = new GuestUser(client, 'Guest Name', 'http://gravatar.com/avatar/abc');
 
@@ -210,7 +210,7 @@ describe('Userデータクラス', () => {
   });
 
   describe('WikidotUser', () => {
-    test('デフォルト値が正しい', () => {
+    test('Default values are correct', () => {
       const client = createMockClient();
       const user = new WikidotUser(client);
 
@@ -221,14 +221,14 @@ describe('Userデータクラス', () => {
       expect(user.ip).toBeNull();
     });
 
-    test('userTypeが"wikidot"である', () => {
+    test('userType is "wikidot"', () => {
       const client = createMockClient();
       const user = new WikidotUser(client);
 
       expect(user.userType).toBe('wikidot');
     });
 
-    test('isWikidotUser()がtrueを返す', () => {
+    test('isWikidotUser() returns true', () => {
       const client = createMockClient();
       const user = new WikidotUser(client);
 
@@ -239,7 +239,7 @@ describe('Userデータクラス', () => {
       expect(user.isWikidotUser()).toBe(true);
     });
 
-    test('toString()が正しい文字列を返す', () => {
+    test('toString() returns correct string', () => {
       const client = createMockClient();
       const user = new WikidotUser(client);
 

--- a/tests/unit/parsers/odate-parser.test.ts
+++ b/tests/unit/parsers/odate-parser.test.ts
@@ -1,19 +1,19 @@
 /**
- * odateパーサーのユニットテスト
+ * odate parser unit tests
  */
 import { describe, expect, test } from 'bun:test';
 import * as cheerio from 'cheerio';
 import { parseOdate } from '../../../src/util/parser';
 
 /**
- * odate HTML要素を生成するヘルパー
+ * Helper to generate odate HTML element
  */
 function makeOdateHtml(unixTimestamp: number): string {
   return `<span class="odate time_${unixTimestamp} format_%25e%20%25b%20%25Y%2C%20%25H%3A%25M|agohover" style="cursor: help; display: inline;">17 Dec 2025, 12:00</span>`;
 }
 
 describe('parseOdate', () => {
-  test('有効なodate要素をパースできる', () => {
+  test('Can parse valid odate element', () => {
     // 2023-12-17 12:00:00 UTC = 1702814400
     const html = makeOdateHtml(1702814400);
     const $ = cheerio.load(html);
@@ -25,7 +25,7 @@ describe('parseOdate', () => {
     expect(result?.getTime()).toBe(1702814400 * 1000);
   });
 
-  test('Unix epoch (0) をパースできる', () => {
+  test('Can parse Unix epoch (0)', () => {
     const html = makeOdateHtml(0);
     const $ = cheerio.load(html);
     const elem = $('span.odate');
@@ -35,7 +35,7 @@ describe('parseOdate', () => {
     expect(result?.getTime()).toBe(0);
   });
 
-  test('複数クラスを持つodate要素をパースできる', () => {
+  test('Can parse odate element with multiple classes', () => {
     const html =
       '<span class="odate time_1702828800 format_%25e another-class">17 Dec 2023, 16:00</span>';
     const $ = cheerio.load(html);
@@ -47,12 +47,12 @@ describe('parseOdate', () => {
     expect(result?.getTime()).toBe(1702828800 * 1000);
   });
 
-  test('time_クラスがない場合はnullを返す', () => {
+  test('Returns null when time_ class is missing', () => {
     const html = '<span class="odate format_%25e%20%25b%20%25Y">17 Dec 2023, 12:00</span>';
     const $ = cheerio.load(html);
     const elem = $('span.odate');
 
-    // 警告ログをキャプチャ
+    // Capture warning log
     const originalWarn = console.warn;
     let warnMessage = '';
     console.warn = (msg: string) => {
@@ -63,14 +63,14 @@ describe('parseOdate', () => {
 
     console.warn = originalWarn;
 
-    // フォールバックでテキストからパースを試みる
-    // パースできればDate、できなければnull
+    // Fallback attempts to parse from text
+    // Returns Date if parseable, null otherwise
     if (result === null) {
       expect(warnMessage).toContain('Failed to parse odate element');
     }
   });
 
-  test('最近のタイムスタンプをパースできる', () => {
+  test('Can parse recent timestamp', () => {
     // 2024-01-01 00:00:00 UTC = 1704067200
     const html = makeOdateHtml(1704067200);
     const $ = cheerio.load(html);
@@ -84,7 +84,7 @@ describe('parseOdate', () => {
     expect(result?.getUTCDate()).toBe(1);
   });
 
-  test('古いタイムスタンプをパースできる', () => {
+  test('Can parse old timestamp', () => {
     // 2007-06-21 00:00:00 UTC (SCP wiki creation date)
     const html = makeOdateHtml(1182384000);
     const $ = cheerio.load(html);
@@ -96,7 +96,7 @@ describe('parseOdate', () => {
     expect(result?.getUTCMonth()).toBe(5); // 0-indexed, June = 5
   });
 
-  test('空の要素をパースするとnullを返す', () => {
+  test('Returns null when parsing empty element', () => {
     const html = '<span class="odate"></span>';
     const $ = cheerio.load(html);
     const elem = $('span.odate');

--- a/tests/unit/parsers/user-parser.test.ts
+++ b/tests/unit/parsers/user-parser.test.ts
@@ -1,5 +1,5 @@
 /**
- * ユーザーパーサーのユニットテスト
+ * User parser unit tests
  */
 import { describe, expect, test } from 'bun:test';
 import * as cheerio from 'cheerio';
@@ -8,7 +8,7 @@ import { AnonymousUser, DeletedUser, GuestUser, User, WikidotUser } from '../../
 import { parseUser } from '../../../src/util/parser';
 
 /**
- * モッククライアントを作成
+ * Create mock client
  */
 function createMockClient(): Client {
   return {
@@ -20,8 +20,8 @@ function createMockClient(): Client {
 describe('parseUser', () => {
   const client = createMockClient();
 
-  describe('通常ユーザー', () => {
-    test('通常ユーザーをパースできる', () => {
+  describe('Regular user', () => {
+    test('Can parse regular user', () => {
       const html = `
         <span class="printuser avatarhover">
           <a href="http://www.wikidot.com/user:info/test-user" onclick="WIKIDOT.page.listeners.userInfo(123456); return false;">
@@ -42,7 +42,7 @@ describe('parseUser', () => {
       expect(user.unixName).toBe('test-user');
     });
 
-    test('ユーザーIDをonclickから抽出できる', () => {
+    test('Can extract user ID from onclick', () => {
       const html = `
         <span class="printuser">
           <a href="http://www.wikidot.com/user:info/another-user" onclick="WIKIDOT.page.listeners.userInfo(789012); return false;">another-user</a>
@@ -58,8 +58,8 @@ describe('parseUser', () => {
     });
   });
 
-  describe('削除済みユーザー', () => {
-    test('削除済みユーザーをパースできる', () => {
+  describe('Deleted user', () => {
+    test('Can parse deleted user', () => {
       const html = `
         <span class="printuser deleted" data-id="123456">(account deleted)</span>
       `;
@@ -72,7 +72,7 @@ describe('parseUser', () => {
       expect((result as DeletedUser).id).toBe(123456);
     });
 
-    test('IDなし削除済みユーザーをパースできる', () => {
+    test('Can parse deleted user without ID', () => {
       const html = `
         <span class="printuser deleted">(account deleted)</span>
       `;
@@ -85,7 +85,7 @@ describe('parseUser', () => {
       expect((result as DeletedUser).id).toBe(0);
     });
 
-    test('テキストが (user deleted) の場合はDeletedUserを返す', () => {
+    test('Returns DeletedUser when text is (user deleted)', () => {
       const html = `
         <span class="printuser">(user deleted)</span>
       `;
@@ -98,8 +98,8 @@ describe('parseUser', () => {
     });
   });
 
-  describe('匿名ユーザー', () => {
-    test('匿名ユーザーをパースできる', () => {
+  describe('Anonymous user', () => {
+    test('Can parse anonymous user', () => {
       const html = `
         <span class="printuser anonymous">Anonymous <span class="ip">(192.168.1.1)</span></span>
       `;
@@ -112,7 +112,7 @@ describe('parseUser', () => {
       expect((result as AnonymousUser).ip).toBe('192.168.1.1');
     });
 
-    test('IPなし匿名ユーザーをパースできる', () => {
+    test('Can parse anonymous user without IP', () => {
       const html = `
         <span class="printuser anonymous">Anonymous</span>
       `;
@@ -126,8 +126,8 @@ describe('parseUser', () => {
     });
   });
 
-  describe('ゲストユーザー', () => {
-    test('ゲストユーザーをパースできる', () => {
+  describe('Guest user', () => {
+    test('Can parse guest user', () => {
       const html = `
         <span class="printuser">
           <img class="small" src="http://www.gravatar.com/avatar/abc123?s=16&amp;d=mm" />
@@ -144,8 +144,8 @@ describe('parseUser', () => {
     });
   });
 
-  describe('Wikidotユーザー', () => {
-    test('Wikidotシステムユーザーをパースできる', () => {
+  describe('Wikidot user', () => {
+    test('Can parse Wikidot system user', () => {
       const html = `
         <span class="printuser">Wikidot</span>
       `;
@@ -158,8 +158,8 @@ describe('parseUser', () => {
     });
   });
 
-  describe('エッジケース', () => {
-    test('リンクがない場合はDeletedUserを返す', () => {
+  describe('Edge cases', () => {
+    test('Returns DeletedUser when no link exists', () => {
       const html = `
         <span class="printuser">Some Unknown User</span>
       `;
@@ -171,7 +171,7 @@ describe('parseUser', () => {
       expect(result).toBeInstanceOf(DeletedUser);
     });
 
-    test('空の要素はDeletedUserを返す', () => {
+    test('Returns DeletedUser for empty element', () => {
       const html = `<span class="printuser"></span>`;
       const $ = cheerio.load(html);
       const elem = $('span.printuser');

--- a/tests/unit/util/quick-module.test.ts
+++ b/tests/unit/util/quick-module.test.ts
@@ -1,33 +1,33 @@
 /**
- * QuickModuleのユニットテスト
+ * QuickModule unit tests
  */
 import { describe, expect, test } from 'bun:test';
 import { QuickModule } from '../../../src/util/quick-module';
 
 describe('QuickModule', () => {
   describe('memberLookup', () => {
-    test('関数が存在する', () => {
+    test('Function exists', () => {
       expect(QuickModule.memberLookup).toBeDefined();
       expect(typeof QuickModule.memberLookup).toBe('function');
     });
 
-    test('サイトIDとクエリを受け取る', () => {
-      // メソッドのシグネチャをテスト
+    test('Accepts site ID and query', () => {
+      // Test method signature
       const result = QuickModule.memberLookup(123456, 'test');
 
-      // ResultAsyncを返す
+      // Returns ResultAsync
       expect(result).toBeDefined();
       expect(typeof result.then).toBe('function');
     });
   });
 
   describe('userLookup', () => {
-    test('関数が存在する', () => {
+    test('Function exists', () => {
       expect(QuickModule.userLookup).toBeDefined();
       expect(typeof QuickModule.userLookup).toBe('function');
     });
 
-    test('サイトIDとクエリを受け取る', () => {
+    test('Accepts site ID and query', () => {
       const result = QuickModule.userLookup(123456, 'test');
 
       expect(result).toBeDefined();
@@ -36,12 +36,12 @@ describe('QuickModule', () => {
   });
 
   describe('pageLookup', () => {
-    test('関数が存在する', () => {
+    test('Function exists', () => {
       expect(QuickModule.pageLookup).toBeDefined();
       expect(typeof QuickModule.pageLookup).toBe('function');
     });
 
-    test('サイトIDとクエリを受け取る', () => {
+    test('Accepts site ID and query', () => {
       const result = QuickModule.pageLookup(123456, 'test');
 
       expect(result).toBeDefined();

--- a/tests/unit/util/string-util.test.ts
+++ b/tests/unit/util/string-util.test.ts
@@ -1,126 +1,126 @@
 /**
- * 文字列ユーティリティのユニットテスト
+ * String utility unit tests
  */
 import { describe, expect, test } from 'bun:test';
 import { toUnix } from '../../../src/util/string-util';
 
 describe('toUnix', () => {
-  describe('基本的な変換', () => {
-    test('小文字に変換される', () => {
+  describe('Basic conversion', () => {
+    test('Converts to lowercase', () => {
       expect(toUnix('ABC')).toBe('abc');
       expect(toUnix('HeLLo')).toBe('hello');
     });
 
-    test('空白がハイフンに変換される', () => {
+    test('Converts spaces to hyphens', () => {
       expect(toUnix('hello world')).toBe('hello-world');
       expect(toUnix('hello  world')).toBe('hello-world');
     });
 
-    test('特殊文字がハイフンに変換される', () => {
+    test('Converts special characters to hyphens', () => {
       expect(toUnix('hello@world')).toBe('hello-world');
       expect(toUnix('hello#world')).toBe('hello-world');
     });
 
-    test('連続するハイフンが単一に変換される', () => {
+    test('Converts consecutive hyphens to single', () => {
       expect(toUnix('hello---world')).toBe('hello-world');
       expect(toUnix('hello--world')).toBe('hello-world');
     });
 
-    test('先頭と末尾のハイフンが削除される', () => {
+    test('Removes leading and trailing hyphens', () => {
       expect(toUnix('-hello-')).toBe('hello');
       expect(toUnix('---hello---')).toBe('hello');
     });
   });
 
-  describe('コロンの処理', () => {
-    test('コロンは保持される', () => {
+  describe('Colon handling', () => {
+    test('Colons are preserved', () => {
       expect(toUnix('category:page')).toBe('category:page');
     });
 
-    test('連続するコロンが単一に変換される', () => {
+    test('Converts consecutive colons to single', () => {
       expect(toUnix('category::page')).toBe('category:page');
     });
 
-    test('先頭と末尾のコロンが削除される', () => {
+    test('Removes leading and trailing colons', () => {
       expect(toUnix(':hello:')).toBe('hello');
     });
 
-    test('コロンとハイフンの組み合わせ', () => {
+    test('Colon and hyphen combination', () => {
       expect(toUnix('category:-page')).toBe('category:page');
       expect(toUnix('category-:page')).toBe('category:page');
     });
   });
 
-  describe('アンダースコアの処理', () => {
-    test('先頭のアンダースコアは保持される', () => {
+  describe('Underscore handling', () => {
+    test('Leading underscore is preserved', () => {
       expect(toUnix('_default')).toBe('_default');
     });
 
-    test('途中のアンダースコアはハイフンに変換される', () => {
+    test('Underscore in middle converts to hyphen', () => {
       expect(toUnix('hello_world')).toBe('hello-world');
     });
 
-    test('コロン後のアンダースコアは保持される', () => {
+    test('Underscore after colon is preserved', () => {
       expect(toUnix('cat:_private')).toBe('cat:_private');
     });
 
-    test('アンダースコアとハイフンの組み合わせ', () => {
+    test('Underscore and hyphen combination', () => {
       expect(toUnix('hello_-world')).toBe('hello-world');
       expect(toUnix('hello-_world')).toBe('hello-world');
     });
   });
 
-  describe('特殊文字の変換', () => {
-    test('ラテン拡張文字がASCIIに変換される', () => {
+  describe('Special character conversion', () => {
+    test('Latin extended characters convert to ASCII', () => {
       expect(toUnix('café')).toBe('cafe');
       expect(toUnix('naïve')).toBe('naive');
       expect(toUnix('résumé')).toBe('resume');
     });
 
-    test('ドイツ語の特殊文字が変換される', () => {
+    test('German special characters are converted', () => {
       expect(toUnix('größe')).toBe('groesse');
       expect(toUnix('Über')).toBe('ueber');
     });
 
-    test('ギリシャ文字が変換される', () => {
+    test('Greek letters are converted', () => {
       expect(toUnix('αβγ')).toBe('avg');
       expect(toUnix('Ωμεγα')).toBe('omega');
     });
 
-    test('キリル文字が変換される', () => {
+    test('Cyrillic letters are converted', () => {
       expect(toUnix('привет')).toBe('privet');
     });
   });
 
-  describe('ページ名の実例', () => {
-    test('SCP記事名', () => {
+  describe('Page name examples', () => {
+    test('SCP article names', () => {
       expect(toUnix('SCP-173')).toBe('scp-173');
       expect(toUnix('SCP-001')).toBe('scp-001');
     });
 
-    test('日本語混じりのページ名（非ASCII文字は削除される）', () => {
+    test('Page name with Japanese (non-ASCII characters are removed)', () => {
       expect(toUnix('日本語ページ')).toBe('');
     });
 
-    test('カテゴリ付きページ名', () => {
+    test('Page name with category', () => {
       expect(toUnix('fragment:scp-173-1')).toBe('fragment:scp-173-1');
     });
   });
 
-  describe('エッジケース', () => {
-    test('空文字列', () => {
+  describe('Edge cases', () => {
+    test('Empty string', () => {
       expect(toUnix('')).toBe('');
     });
 
-    test('数字のみ', () => {
+    test('Numbers only', () => {
       expect(toUnix('12345')).toBe('12345');
     });
 
-    test('ハイフンのみ', () => {
+    test('Hyphens only', () => {
       expect(toUnix('---')).toBe('');
     });
 
-    test('コロンのみ', () => {
+    test('Colons only', () => {
       expect(toUnix(':::')).toBe('');
     });
   });


### PR DESCRIPTION
## Summary

- README.md, CLAUDE.md, llms.txt を英語化
- tests/integration/README.md を英語化
- GitHub テンプレート（ISSUE_TEMPLATE, PR_TEMPLATE）を英語化
- src/ 配下の全ソースファイルのJSDocコメントを英語化
- tests/ 配下の全テストファイルのコメントを英語化

## Test plan

- [x] bun run lint - 成功
- [x] bun run format - 成功
- [x] bun run typecheck - 成功
- [x] bun test - 266テスト全成功