### PR TITLE
fix: SearchPagesQueryのpagetypeとcategoryを常にリクエストに含める

### DIFF
--- a/src/module/page/search-query.ts
+++ b/src/module/page/search-query.ts
@@ -146,8 +146,11 @@ export class SearchPagesQuery {
   asDict(): Record<string, unknown> {
     const result: Record<string, unknown> = {};
 
-    if (this.pagetype !== '*') result.pagetype = this.pagetype;
-    if (this.category !== '*') result.category = this.category;
+    // pagetype and category must always be included
+    // Wikidot defaults: pagetype="normal", category="." (current category)
+    // To get all pages, we need to explicitly send "*"
+    result.pagetype = this.pagetype;
+    result.category = this.category;
     if (this.tags !== null) {
       result.tags = Array.isArray(this.tags) ? this.tags.join(' ') : this.tags;
     }


### PR DESCRIPTION
## Summary
- `site.pages.all()` や `site.pages.search({})` で `_default` カテゴリのページだけが取得される問題を修正
- `SearchPagesQuery.asDict()` で `pagetype` と `category` を常にリクエストに含めるように変更

## Root Cause
Wikidotのデフォルト値:
- `pagetype`: `"normal"` (アンダースコアなしのページのみ)
- `category`: `"."` (現在のカテゴリ = APIコール時は `_default`)

従来の実装では `"*"` の場合にリクエストから除外していたため、Wikidotのデフォルト値が適用されていた。

## Fix
`pagetype` と `category` を常にリクエストに含めることで、`"*"` を明示的に送信し、全カテゴリ・全タイプのページを取得可能にした。

## Test plan
- [x] bun run lint
- [x] bun run typecheck
- [x] bun test