### PR TITLE
fix: トランスポートエラーのリトライ対応を明確化

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ukwhatn/wikidot",
-  "version": "4.1.1",
+  "version": "4.1.2",
   "description": "TypeScript library for interacting with Wikidot sites",
   "type": "module",
   "main": "./dist/index.cjs",

--- a/src/connector/amc-client.ts
+++ b/src/connector/amc-client.ts
@@ -350,7 +350,8 @@ export class AMCClient {
 
         return wdOkAsync(amcResponse);
       } catch (error) {
-        // Retry on HTTP error
+        // Retry on all errors (HTTP errors, network errors, timeouts, etc.)
+        // Wikidot server has a relatively high error rate, so retry is essential
         retryCount++;
         if (retryCount >= this.config.retryLimit) {
           const statusCode =
@@ -358,9 +359,7 @@ export class AMCClient {
               ? ((error as { response?: { status?: number } }).response?.status ??
                 DEFAULT_HTTP_STATUS_CODE)
               : DEFAULT_HTTP_STATUS_CODE;
-          return wdErrAsync(
-            new AMCHttpError(`AMC HTTP request failed: ${String(error)}`, statusCode)
-          );
+          return wdErrAsync(new AMCHttpError(`AMC request failed: ${String(error)}`, statusCode));
         }
 
         const backoff = calculateBackoff(


### PR DESCRIPTION
## 概要

ネットワークエラー（接続切断、タイムアウト等）でリトライが行われることを明確化。

## 変更内容

- catchブロックのコメントを改善: HTTPエラーだけでなくネットワークエラー、タイムアウト等も含むことを明記
- エラーメッセージを「AMC HTTP request failed」から「AMC request failed」に変更（ネットワークエラーも含むため）
- Wikidotサーバーのエラー率が高いことをコメントに記載

## 備考

TypeScript版は既に全てのエラーをcatchしてリトライする実装になっていたため、コメントとエラーメッセージの改善のみ。
Python版（wikidot.py）では実際のコード修正が必要。