### PR TITLE
feat: バッチ取得機能を追加

### DIFF
--- a/src/module/forum/forum-thread.ts
+++ b/src/module/forum/forum-thread.ts
@@ -64,7 +64,17 @@ export class ForumThread {
       return fromPromise(Promise.resolve(this._posts), (e) => new UnexpectedError(String(e)));
     }
 
-    return ForumPostCollection.acquireAllInThread(this);
+    return fromPromise(
+      (async () => {
+        const result = await ForumPostCollection.acquireAllInThreads([this]);
+        if (result.isErr()) {
+          throw result.error;
+        }
+        this._posts = result.value.get(this.id) ?? new ForumPostCollection(this, []);
+        return this._posts;
+      })(),
+      (error) => new UnexpectedError(`Failed to get posts: ${String(error)}`)
+    );
   }
 
   /**


### PR DESCRIPTION
## Summary

- `PageCollection.getPageFiles()`: 複数ページのファイルを一括取得
- `ForumPostCollection.acquireAllInThreads()`: 複数スレッドの投稿を一括取得（ページネーション対応）
- `ForumPostRevisionCollection.acquireAllForPosts()`: 複数投稿のリビジョンを一括取得（withHtml オプション付き）

各バッチメソッドに対応して、単体取得メソッド（`Page.getFiles()`, `ForumThread.getPosts()`, `ForumPost.getRevisions()`）もバッチメソッドを内部で使用するように修正。

## Test plan

- [x] 既存テスト全パス（284 tests）
- [x] 型チェック通過
- [x] Lint/Format通過