### PR TITLE
chore: bump version to 4.2.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ukwhatn/wikidot",
-  "version": "4.2.0",
+  "version": "4.2.1",
   "description": "TypeScript library for interacting with Wikidot sites",
   "type": "module",
   "main": "./dist/index.cjs",

--- a/src/connector/amc-client.ts
+++ b/src/connector/amc-client.ts
@@ -10,6 +10,7 @@ import {
   WikidotStatusError,
 } from '../common/errors';
 import { fromPromise, type WikidotResultAsync, wdErrAsync, wdOkAsync } from '../common/types';
+import { fetchWithRetry } from '../util/http';
 import {
   type AMCConfig,
   DEFAULT_AMC_CONFIG,
@@ -135,9 +136,10 @@ export class AMCClient {
 
     return fromPromise(
       (async () => {
-        const response = await fetch(`http://${siteName}.${this.domain}`, {
+        const response = await fetchWithRetry(`http://${siteName}.${this.domain}`, this.config, {
           method: 'GET',
           redirect: 'manual',
+          checkOk: false, // Don't retry on HTTP errors (301 is expected)
         });
 
         // 404 means site does not exist

--- a/src/module/user/user.ts
+++ b/src/module/user/user.ts
@@ -3,6 +3,7 @@ import pLimit from 'p-limit';
 import { NoElementError, NotFoundException, UnexpectedError } from '../../common/errors';
 import { fromPromise, type WikidotResultAsync } from '../../common/types';
 import { DEFAULT_AMC_CONFIG } from '../../connector/amc-config';
+import { fetchWithRetry } from '../../util/http';
 import { toUnix } from '../../util/string-util';
 import type { ClientRef } from '../types';
 import type { AbstractUser, UserType } from './abstract-user';
@@ -67,7 +68,9 @@ export class User implements AbstractUser {
         const unixName = toUnix(name);
         const url = `https://www.wikidot.com/user:info/${unixName}`;
 
-        const response = await fetch(url);
+        const response = await fetchWithRetry(url, DEFAULT_AMC_CONFIG, {
+          checkOk: false, // Handle HTTP errors manually
+        });
         if (!response.ok) {
           throw new UnexpectedError(`Failed to fetch user info: ${response.status}`);
         }

--- a/src/util/http.ts
+++ b/src/util/http.ts
@@ -1,0 +1,80 @@
+/**
+ * HTTP utilities with retry mechanism
+ */
+import type { AMCConfig } from '../connector/amc-config';
+import { DEFAULT_AMC_CONFIG } from '../connector/amc-config';
+
+/**
+ * Calculate backoff time with exponential backoff and jitter
+ * @param retryCount - Current retry count (1-based)
+ * @param baseInterval - Base interval in milliseconds
+ * @param backoffFactor - Exponential backoff factor
+ * @param maxBackoff - Maximum backoff time in milliseconds
+ * @returns Backoff time in milliseconds
+ */
+export function calculateBackoff(
+  retryCount: number,
+  baseInterval: number,
+  backoffFactor: number,
+  maxBackoff: number
+): number {
+  const backoff = baseInterval * backoffFactor ** (retryCount - 1);
+  const jitter = Math.random() * backoff * 0.1;
+  return Math.min(backoff + jitter, maxBackoff);
+}
+
+/**
+ * Sleep for specified milliseconds
+ */
+function sleep(ms: number): Promise<void> {
+  return new Promise((resolve) => setTimeout(resolve, ms));
+}
+
+/**
+ * Options for fetchWithRetry
+ */
+export interface FetchWithRetryOptions extends Omit<RequestInit, 'signal'> {
+  /** Whether to check response.ok (default: true) */
+  checkOk?: boolean;
+}
+
+/**
+ * Fetch with automatic retry on timeout/network errors
+ * @param url - URL to fetch
+ * @param config - AMC configuration (uses timeout, retryLimit, retryInterval, maxBackoff, backoffFactor)
+ * @param options - Fetch options (RequestInit without signal)
+ * @returns Response
+ * @throws Error on all retries exhausted
+ */
+export async function fetchWithRetry(
+  url: string,
+  config: AMCConfig = DEFAULT_AMC_CONFIG,
+  options: FetchWithRetryOptions = {}
+): Promise<Response> {
+  const { checkOk = true, ...fetchOptions } = options;
+
+  for (let attempt = 0; attempt < config.retryLimit; attempt++) {
+    try {
+      const response = await fetch(url, {
+        ...fetchOptions,
+        signal: AbortSignal.timeout(config.timeout),
+      });
+      if (checkOk && !response.ok) {
+        throw new Error(`HTTP ${response.status}: ${response.statusText}`);
+      }
+      return response;
+    } catch (error) {
+      if (attempt >= config.retryLimit - 1) {
+        throw error;
+      }
+      const backoff = calculateBackoff(
+        attempt + 1,
+        config.retryInterval,
+        config.backoffFactor,
+        config.maxBackoff
+      );
+      await sleep(backoff);
+    }
+  }
+  throw new Error('Unreachable');
+}

--- a/src/util/quick-module.ts
+++ b/src/util/quick-module.ts
@@ -7,6 +7,8 @@
 import { z } from 'zod';
 import { NotFoundException, UnexpectedError } from '../common/errors';
 import { fromPromise, type WikidotResultAsync } from '../common/types';
+import { DEFAULT_AMC_CONFIG } from '../connector/amc-config';
+import { fetchWithRetry } from './http';
 
 /**
  * QuickModule module name
@@ -66,11 +68,12 @@ async function requestQuickModule(
 ): Promise<unknown> {
   const url = `https://www.wikidot.com/quickmodule.php?module=${moduleName}&s=${siteId}&q=${encodeURIComponent(query)}`;
 
-  const response = await fetch(url, {
+  const response = await fetchWithRetry(url, DEFAULT_AMC_CONFIG, {
     method: 'GET',
     headers: {
       Accept: 'application/json',
     },
+    checkOk: false, // Handle HTTP errors manually
   });
 
   if (response.status === 500) {


### PR DESCRIPTION
## Summary
- 全fetch箇所にリトライ機構を追加
- バージョン4.2.1にバンプ

## Changes
- `src/util/http.ts`: 共通リトライユーティリティを新規作成
- `src/module/page/page.ts`: acquirePageIds, acquirePageFilesにリトライを適用
- `src/connector/auth.ts`: ログインにリトライを適用（3回制限）
- `src/connector/amc-client.ts`: SSLチェックにリトライを適用
- `src/module/site/site.ts`: fromUnixNameにリトライを適用
- `src/module/user/user.ts`: fromNameにリトライを適用
- `src/util/quick-module.ts`: requestQuickModuleにリトライを適用