### PR TITLE
chore: dependabot cooldownを追加

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -17,6 +17,9 @@ updates:
         patterns:
           - "@biomejs/*"
           - "typescript"
+    cooldown:
+      default-days: 3
+      semver-patch-days: 1
   - package-ecosystem: "github-actions"
     directory: "/"
     schedule:


### PR DESCRIPTION
## Summary
- bunエコシステムにcooldown設定を追加
  - `default-days: 3`
  - `semver-patch-days: 1`

## Reference
- https://docs.github.com/en/code-security/dependabot/working-with-dependabot/dependabot-options-reference