### PR TITLE
feat: amc_requestの部分失敗耐性を追加

### DIFF
--- a/biome.json
+++ b/biome.json
@@ -1,5 +1,5 @@
 {
-  "$schema": "https://biomejs.dev/schemas/2.3.10/schema.json",
+  "$schema": "https://biomejs.dev/schemas/2.3.13/schema.json",
   "vcs": {
     "enabled": true,
     "clientKind": "git",

--- a/bun.lock
+++ b/bun.lock
@@ -12,7 +12,7 @@
         "zod": "^4.2.1",
       },
       "devDependencies": {
-        "@biomejs/biome": "^2.3.10",
+        "@biomejs/biome": "2.3.13",
         "@types/bun": "^1.1.0",
         "bunup": "^0.16.11",
         "typescript": "^5.5.0",
@@ -31,23 +31,23 @@
 
     "@babel/types": ["@babel/types@7.28.5", "", { "dependencies": { "@babel/helper-string-parser": "^7.27.1", "@babel/helper-validator-identifier": "^7.28.5" } }, "sha512-qQ5m48eI/MFLQ5PxQj4PFaprjyCTLI37ElWMmNs0K8Lk3dVeOdNpB3ks8jc7yM5CDmVC73eMVk/trk3fgmrUpA=="],
 
-    "@biomejs/biome": ["@biomejs/biome@2.3.11", "", { "optionalDependencies": { "@biomejs/cli-darwin-arm64": "2.3.11", "@biomejs/cli-darwin-x64": "2.3.11", "@biomejs/cli-linux-arm64": "2.3.11", "@biomejs/cli-linux-arm64-musl": "2.3.11", "@biomejs/cli-linux-x64": "2.3.11", "@biomejs/cli-linux-x64-musl": "2.3.11", "@biomejs/cli-win32-arm64": "2.3.11", "@biomejs/cli-win32-x64": "2.3.11" }, "bin": { "biome": "bin/biome" } }, "sha512-/zt+6qazBWguPG6+eWmiELqO+9jRsMZ/DBU3lfuU2ngtIQYzymocHhKiZRyrbra4aCOoyTg/BmY+6WH5mv9xmQ=="],
+    "@biomejs/biome": ["@biomejs/biome@2.3.13", "", { "optionalDependencies": { "@biomejs/cli-darwin-arm64": "2.3.13", "@biomejs/cli-darwin-x64": "2.3.13", "@biomejs/cli-linux-arm64": "2.3.13", "@biomejs/cli-linux-arm64-musl": "2.3.13", "@biomejs/cli-linux-x64": "2.3.13", "@biomejs/cli-linux-x64-musl": "2.3.13", "@biomejs/cli-win32-arm64": "2.3.13", "@biomejs/cli-win32-x64": "2.3.13" }, "bin": { "biome": "bin/biome" } }, "sha512-Fw7UsV0UAtWIBIm0M7g5CRerpu1eKyKAXIazzxhbXYUyMkwNrkX/KLkGI7b+uVDQ5cLUMfOC9vR60q9IDYDstA=="],
 
-    "@biomejs/cli-darwin-arm64": ["@biomejs/cli-darwin-arm64@2.3.11", "", { "os": "darwin", "cpu": "arm64" }, "sha512-/uXXkBcPKVQY7rc9Ys2CrlirBJYbpESEDme7RKiBD6MmqR2w3j0+ZZXRIL2xiaNPsIMMNhP1YnA+jRRxoOAFrA=="],
+    "@biomejs/cli-darwin-arm64": ["@biomejs/cli-darwin-arm64@2.3.13", "", { "os": "darwin", "cpu": "arm64" }, "sha512-0OCwP0/BoKzyJHnFdaTk/i7hIP9JHH9oJJq6hrSCPmJPo8JWcJhprK4gQlhFzrwdTBAW4Bjt/RmCf3ZZe59gwQ=="],
 
-    "@biomejs/cli-darwin-x64": ["@biomejs/cli-darwin-x64@2.3.11", "", { "os": "darwin", "cpu": "x64" }, "sha512-fh7nnvbweDPm2xEmFjfmq7zSUiox88plgdHF9OIW4i99WnXrAC3o2P3ag9judoUMv8FCSUnlwJCM1B64nO5Fbg=="],
+    "@biomejs/cli-darwin-x64": ["@biomejs/cli-darwin-x64@2.3.13", "", { "os": "darwin", "cpu": "x64" }, "sha512-AGr8OoemT/ejynbIu56qeil2+F2WLkIjn2d8jGK1JkchxnMUhYOfnqc9sVzcRxpG9Ycvw4weQ5sprRvtb7Yhcw=="],
 
-    "@biomejs/cli-linux-arm64": ["@biomejs/cli-linux-arm64@2.3.11", "", { "os": "linux", "cpu": "arm64" }, "sha512-l4xkGa9E7Uc0/05qU2lMYfN1H+fzzkHgaJoy98wO+b/7Gl78srbCRRgwYSW+BTLixTBrM6Ede5NSBwt7rd/i6g=="],
+    "@biomejs/cli-linux-arm64": ["@biomejs/cli-linux-arm64@2.3.13", "", { "os": "linux", "cpu": "arm64" }, "sha512-xvOiFkrDNu607MPMBUQ6huHmBG1PZLOrqhtK6pXJW3GjfVqJg0Z/qpTdhXfcqWdSZHcT+Nct2fOgewZvytESkw=="],
 
-    "@biomejs/cli-linux-arm64-musl": ["@biomejs/cli-linux-arm64-musl@2.3.11", "", { "os": "linux", "cpu": "arm64" }, "sha512-XPSQ+XIPZMLaZ6zveQdwNjbX+QdROEd1zPgMwD47zvHV+tCGB88VH+aynyGxAHdzL+Tm/+DtKST5SECs4iwCLg=="],
+    "@biomejs/cli-linux-arm64-musl": ["@biomejs/cli-linux-arm64-musl@2.3.13", "", { "os": "linux", "cpu": "arm64" }, "sha512-TUdDCSY+Eo/EHjhJz7P2GnWwfqet+lFxBZzGHldrvULr59AgahamLs/N85SC4+bdF86EhqDuuw9rYLvLFWWlXA=="],
 
-    "@biomejs/cli-linux-x64": ["@biomejs/cli-linux-x64@2.3.11", "", { "os": "linux", "cpu": "x64" }, "sha512-/1s9V/H3cSe0r0Mv/Z8JryF5x9ywRxywomqZVLHAoa/uN0eY7F8gEngWKNS5vbbN/BsfpCG5yeBT5ENh50Frxg=="],
+    "@biomejs/cli-linux-x64": ["@biomejs/cli-linux-x64@2.3.13", "", { "os": "linux", "cpu": "x64" }, "sha512-s+YsZlgiXNq8XkgHs6xdvKDFOj/bwTEevqEY6rC2I3cBHbxXYU1LOZstH3Ffw9hE5tE1sqT7U23C00MzkXztMw=="],
 
-    "@biomejs/cli-linux-x64-musl": ["@biomejs/cli-linux-x64-musl@2.3.11", "", { "os": "linux", "cpu": "x64" }, "sha512-vU7a8wLs5C9yJ4CB8a44r12aXYb8yYgBn+WeyzbMjaCMklzCv1oXr8x+VEyWodgJt9bDmhiaW/I0RHbn7rsNmw=="],
+    "@biomejs/cli-linux-x64-musl": ["@biomejs/cli-linux-x64-musl@2.3.13", "", { "os": "linux", "cpu": "x64" }, "sha512-0bdwFVSbbM//Sds6OjtnmQGp4eUjOTt6kHvR/1P0ieR9GcTUAlPNvPC3DiavTqq302W34Ae2T6u5VVNGuQtGlQ=="],
 
-    "@biomejs/cli-win32-arm64": ["@biomejs/cli-win32-arm64@2.3.11", "", { "os": "win32", "cpu": "arm64" }, "sha512-PZQ6ElCOnkYapSsysiTy0+fYX+agXPlWugh6+eQ6uPKI3vKAqNp6TnMhoM3oY2NltSB89hz59o8xIfOdyhi9Iw=="],
+    "@biomejs/cli-win32-arm64": ["@biomejs/cli-win32-arm64@2.3.13", "", { "os": "win32", "cpu": "arm64" }, "sha512-QweDxY89fq0VvrxME+wS/BXKmqMrOTZlN9SqQ79kQSIc3FrEwvW/PvUegQF6XIVaekncDykB5dzPqjbwSKs9DA=="],
 
-    "@biomejs/cli-win32-x64": ["@biomejs/cli-win32-x64@2.3.11", "", { "os": "win32", "cpu": "x64" }, "sha512-43VrG813EW+b5+YbDbz31uUsheX+qFKCpXeY9kfdAx+ww3naKxeVkTD9zLIWxUPfJquANMHrmW3wbe/037G0Qg=="],
+    "@biomejs/cli-win32-x64": ["@biomejs/cli-win32-x64@2.3.13", "", { "os": "win32", "cpu": "x64" }, "sha512-trDw2ogdM2lyav9WFQsdsfdVy1dvZALymRpgmWsvSez0BJzBjulhOT/t+wyKeh3pZWvwP3VMs1SoOKwO3wecMQ=="],
 
     "@bunup/dts": ["@bunup/dts@0.14.46", "", { "dependencies": { "@babel/parser": "^7.28.4", "coffi": "^0.1.37", "oxc-minify": "^0.93.0", "oxc-resolver": "^11.9.0", "oxc-transform": "^0.93.0", "picocolors": "^1.1.1", "std-env": "^3.9.0", "ts-import-resolver": "^0.1.23" }, "peerDependencies": { "typescript": ">=4.5.0" }, "optionalPeers": ["typescript"] }, "sha512-3U1cTvieC7Qjrwiqi8kwWIDwnhTcJvCJF6qc492oo+1pd9bvgScpd24ZCAox0YXo1a5UmqgxQKzGVXqzCrCnFQ=="],
 

--- a/package.json
+++ b/package.json
@@ -72,7 +72,7 @@
     "zod": "^4.2.1"
   },
   "devDependencies": {
-    "@biomejs/biome": "^2.3.10",
+    "@biomejs/biome": "2.3.13",
     "@types/bun": "^1.1.0",
     "bunup": "^0.16.11",
     "typescript": "^5.5.0"

--- a/src/module/forum/forum-post.ts
+++ b/src/module/forum/forum-post.ts
@@ -424,7 +424,7 @@ export class ForumPostCollection extends Array<ForumPost> {
         const site = threads[0]!.site;
 
         // Step 1: Get first page of all threads
-        const firstPageResult = await site.amcRequest(
+        const firstPageResult = await site.amcRequestWithRetry(
           threads.map((thread) => ({
             moduleName: 'forum/ForumViewThreadPostsModule',
             pageNo: '1',
@@ -471,7 +471,7 @@ export class ForumPostCollection extends Array<ForumPost> {
 
         // Step 3: Fetch additional pages
         if (additionalRequests.length > 0) {
-          const additionalResult = await site.amcRequest(
+          const additionalResult = await site.amcRequestWithRetry(
             additionalRequests.map(({ thread, page }) => ({
               moduleName: 'forum/ForumViewThreadPostsModule',
               pageNo: String(page),

--- a/src/module/forum/forum-thread.ts
+++ b/src/module/forum/forum-thread.ts
@@ -259,12 +259,13 @@ export class ForumThreadCollection extends Array<ForumThread> {
           });
         }
 
-        const additionalResults = await category.site.amcRequest(bodies);
+        const additionalResults = await category.site.amcRequestWithRetry(bodies);
         if (additionalResults.isErr()) {
           throw additionalResults.error;
         }
 
         for (const response of additionalResults.value) {
+          if (!response) continue;
           const body = String(response?.body ?? '');
           const $ = cheerio.load(body);
 

--- a/src/module/page/page.ts
+++ b/src/module/page/page.ts
@@ -876,7 +876,7 @@ export class PageCollection extends Array<Page> {
           return new PageCollection(site, pages);
         }
 
-        const result = await site.amcRequest(
+        const result = await site.amcRequestWithRetry(
           targetPages.map((page) => ({
             moduleName: 'history/PageRevisionListModule',
             page_id: page.id,
@@ -957,7 +957,7 @@ export class PageCollection extends Array<Page> {
           return new PageCollection(site, pages);
         }
 
-        const result = await site.amcRequest(
+        const result = await site.amcRequestWithRetry(
           targetPages.map((page) => ({
             moduleName: 'pagerate/WhoRatedPageModule',
             pageId: page.id,

--- a/src/module/site/site.ts
+++ b/src/module/site/site.ts
@@ -1,5 +1,6 @@
 import * as cheerio from 'cheerio';
-import { NoElementError, NotFoundException, UnexpectedError } from '../../common/errors';
+import { NoElementError, NotFoundException, UnexpectedError, WikidotError } from '../../common/errors';
+import { logger } from '../../common/logger';
 import { fromPromise, type WikidotResultAsync } from '../../common/types';
 import type { AMCRequestBody, AMCResponse } from '../../connector';
 import { fetchWithRetry } from '../../util/http';
@@ -113,10 +114,76 @@ export class Site {
   /**
    * Execute AMC request to this site
    * @param bodies - Request body array
+   * @param options - Request options
    * @returns AMC response array
    */
-  amcRequest(bodies: AMCRequestBody[]): WikidotResultAsync<AMCResponse[]> {
-    return this.client.amcClient.request(bodies, this.unixName, this.sslSupported);
+  amcRequest(bodies: AMCRequestBody[]): WikidotResultAsync<AMCResponse[]>;
+  amcRequest(
+    bodies: AMCRequestBody[],
+    options: { returnExceptions: true }
+  ): WikidotResultAsync<(AMCResponse | WikidotError)[]>;
+  amcRequest(
+    bodies: AMCRequestBody[],
+    options?: { returnExceptions?: boolean }
+  ): WikidotResultAsync<AMCResponse[]> | WikidotResultAsync<(AMCResponse | WikidotError)[]> {
+    return this.client.amcClient.requestWithOptions(bodies, {
+      siteName: this.unixName,
+      sslSupported: this.sslSupported,
+      returnExceptions: options?.returnExceptions ?? false,
+    });
+  }
+
+  /**
+   * Execute AMC request with partial failure tolerance.
+   * Failed requests are retried once. Still-failed requests return null.
+   * @param bodies - Request body array
+   * @returns AMC response array (null for permanently failed requests)
+   */
+  amcRequestWithRetry(bodies: AMCRequestBody[]): WikidotResultAsync<(AMCResponse | null)[]> {
+    return fromPromise(
+      (async () => {
+        const initialResult = await this.amcRequest(bodies, { returnExceptions: true });
+        if (initialResult.isErr()) throw initialResult.error;
+
+        const results: (AMCResponse | null)[] = [];
+        const failedIndices: number[] = [];
+
+        for (const [i, respOrErr] of initialResult.value.entries()) {
+          if (respOrErr instanceof WikidotError) {
+            results.push(null);
+            failedIndices.push(i);
+          } else {
+            results.push(respOrErr);
+          }
+        }
+
+        if (failedIndices.length > 0) {
+          const retryBodies = failedIndices.map((i) => bodies[i]!);
+          logger.warn(
+            `amcRequestWithRetry: ${failedIndices.length}/${bodies.length} requests failed, retrying`
+          );
+          const retryResult = await this.amcRequest(retryBodies, { returnExceptions: true });
+          if (retryResult.isOk()) {
+            for (let j = 0; j < failedIndices.length; j++) {
+              const retryResp = retryResult.value[j];
+              if (retryResp && !(retryResp instanceof WikidotError)) {
+                results[failedIndices[j]!] = retryResp;
+              } else {
+                logger.warn(
+                  `amcRequestWithRetry: retry failed, skipping: ${retryResp instanceof WikidotError ? retryResp.message : "unknown"}`
+                );
+              }
+            }
+          }
+        }
+
+        return results;
+      })(),
+      (error) => {
+        if (error instanceof WikidotError) return error;
+        return new UnexpectedError(`AMC request with retry failed: ${String(error)}`);
+      }
+    );
   }
 
   /**

--- a/src/module/site/site.ts
+++ b/src/module/site/site.ts
@@ -1,5 +1,10 @@
 import * as cheerio from 'cheerio';
-import { NoElementError, NotFoundException, UnexpectedError, WikidotError } from '../../common/errors';
+import {
+  NoElementError,
+  NotFoundException,
+  UnexpectedError,
+  WikidotError,
+} from '../../common/errors';
 import { logger } from '../../common/logger';
 import { fromPromise, type WikidotResultAsync } from '../../common/types';
 import type { AMCRequestBody, AMCResponse } from '../../connector';
@@ -170,7 +175,7 @@ export class Site {
                 results[failedIndices[j]!] = retryResp;
               } else {
                 logger.warn(
-                  `amcRequestWithRetry: retry failed, skipping: ${retryResp instanceof WikidotError ? retryResp.message : "unknown"}`
+                  `amcRequestWithRetry: retry failed, skipping: ${retryResp instanceof WikidotError ? retryResp.message : 'unknown'}`
                 );
               }
             }

--- a/src/module/types.ts
+++ b/src/module/types.ts
@@ -2,6 +2,7 @@
  * Common interface definitions to avoid circular dependencies
  */
 
+import type { WikidotError } from '../common/errors';
 import type { WikidotResultAsync } from '../common/types';
 import type { AMCRequestBody, AMCResponse } from '../connector';
 
@@ -81,11 +82,20 @@ export interface SiteRef {
    * Execute AMC request
    */
   amcRequest(bodies: AMCRequestBody[]): WikidotResultAsync<AMCResponse[]>;
+  amcRequest(
+    bodies: AMCRequestBody[],
+    options: { returnExceptions: true }
+  ): WikidotResultAsync<(AMCResponse | WikidotError)[]>;
 
   /**
    * Execute single AMC request
    */
   amcRequestSingle(body: AMCRequestBody): WikidotResultAsync<AMCResponse>;
+
+  /**
+   * Execute AMC request with partial failure tolerance
+   */
+  amcRequestWithRetry(bodies: AMCRequestBody[]): WikidotResultAsync<(AMCResponse | null)[]>;
 }
 
 /**


### PR DESCRIPTION
## Summary
- `Site.amcRequestWithRetry()` メソッドを追加: 大量並列リクエストで一部が失敗した場合、失敗分のみ1回リトライし、それでも失敗した分はnullを返す
- `Site.amcRequest()` に `returnExceptions` オプションを追加（内部利用）
- 以下の4メソッドの大量リクエスト部分を `amcRequestWithRetry` 経由に変更:
  - `ForumThreadCollection.acquireAllInCategory()`
  - `ForumPostCollection.acquireAllInThreads()`（2箇所）
  - `PageCollection.acquirePageRevisions()`
  - `PageCollection.acquirePageVotes()`

## Background
panopticon-batchのSync Forum GHAが、~1,352ページの並列取得で数ページ（0.07%〜0.4%）が失敗するために100%失敗していた。既存の5回リトライ（指数バックオフ）を経ても失敗するケースで、成功した残り99.6%の結果も破棄される設計だった。

## Test plan
- [x] `bun run format` — OK
- [x] `bun run lint` — OK（既存警告のみ）
- [x] `bun run typecheck` — OK
- [x] `bun test` — 288 pass（1 fail は外部Wikidot接続の統合テストタイムアウト、今回の変更とは無関係）
- [ ] panopticon Sync Forum GHAで最終確認