### PR TITLE
feat: amcRequestWithRetryにバッチ分割・複数回リトライ・Config対応を追加

### DIFF
--- a/src/connector/amc-config.ts
+++ b/src/connector/amc-config.ts
@@ -19,6 +19,12 @@ export interface AMCConfig {
 
   /** Maximum concurrent requests */
   semaphoreLimit: number;
+
+  /** Batch size for amcRequestWithRetry */
+  retryBatchSize: number;
+
+  /** Maximum retry attempts for amcRequestWithRetry */
+  retryMaxRetries: number;
 }
 
 /** Default AMC configuration */
@@ -29,6 +35,8 @@ export const DEFAULT_AMC_CONFIG: AMCConfig = {
   maxBackoff: 60000,
   backoffFactor: 2.0,
   semaphoreLimit: 10,
+  retryBatchSize: 50,
+  retryMaxRetries: 3,
 };
 
 /**

--- a/src/module/site/site.ts
+++ b/src/module/site/site.ts
@@ -152,15 +152,15 @@ export class Site {
     const batchSize = options?.batchSize ?? this.client.amcClient.config.retryBatchSize;
     const maxRetries = options?.maxRetries ?? this.client.amcClient.config.retryMaxRetries;
 
-    if (!Number.isFinite(batchSize) || batchSize <= 0) {
-      throw new Error(`Invalid batchSize: ${batchSize}. Must be a positive integer.`);
-    }
-    if (!Number.isFinite(maxRetries) || maxRetries < 0) {
-      throw new Error(`Invalid maxRetries: ${maxRetries}. Must be a non-negative integer.`);
-    }
-
     return fromPromise(
       (async () => {
+        if (!Number.isInteger(batchSize) || batchSize <= 0) {
+          throw new Error(`Invalid batchSize: ${batchSize}. Must be a positive integer.`);
+        }
+        if (!Number.isInteger(maxRetries) || maxRetries < 0) {
+          throw new Error(`Invalid maxRetries: ${maxRetries}. Must be a non-negative integer.`);
+        }
+
         const allResults: (AMCResponse | null)[] = [];
 
         for (let batchStart = 0; batchStart < bodies.length; batchStart += batchSize) {

--- a/src/module/site/site.ts
+++ b/src/module/site/site.ts
@@ -140,49 +140,71 @@ export class Site {
 
   /**
    * Execute AMC request with partial failure tolerance.
-   * Failed requests are retried once. Still-failed requests return null.
+   * Requests are split into batches and failed requests are retried.
    * @param bodies - Request body array
+   * @param options - Optional batch size and max retries
    * @returns AMC response array (null for permanently failed requests)
    */
-  amcRequestWithRetry(bodies: AMCRequestBody[]): WikidotResultAsync<(AMCResponse | null)[]> {
+  amcRequestWithRetry(
+    bodies: AMCRequestBody[],
+    options?: { batchSize?: number; maxRetries?: number }
+  ): WikidotResultAsync<(AMCResponse | null)[]> {
+    const batchSize = options?.batchSize ?? 50;
+    const maxRetries = options?.maxRetries ?? 3;
+
     return fromPromise(
       (async () => {
-        const initialResult = await this.amcRequest(bodies, { returnExceptions: true });
-        if (initialResult.isErr()) throw initialResult.error;
+        const allResults: (AMCResponse | null)[] = [];
 
-        const results: (AMCResponse | null)[] = [];
-        const failedIndices: number[] = [];
+        for (let batchStart = 0; batchStart < bodies.length; batchStart += batchSize) {
+          const batch = bodies.slice(batchStart, batchStart + batchSize);
 
-        for (const [i, respOrErr] of initialResult.value.entries()) {
-          if (respOrErr instanceof WikidotError) {
-            results.push(null);
-            failedIndices.push(i);
-          } else {
-            results.push(respOrErr);
+          const initialResult = await this.amcRequest(batch, { returnExceptions: true });
+          if (initialResult.isErr()) throw initialResult.error;
+
+          const batchResults: (AMCResponse | null)[] = [];
+          let failedIndices: number[] = [];
+
+          for (const [i, respOrErr] of initialResult.value.entries()) {
+            if (respOrErr instanceof WikidotError) {
+              batchResults.push(null);
+              failedIndices.push(i);
+            } else {
+              batchResults.push(respOrErr);
+            }
           }
-        }
 
-        if (failedIndices.length > 0) {
-          const retryBodies = failedIndices.map((i) => bodies[i]!);
-          logger.warn(
-            `amcRequestWithRetry: ${failedIndices.length}/${bodies.length} requests failed, retrying`
-          );
-          const retryResult = await this.amcRequest(retryBodies, { returnExceptions: true });
-          if (retryResult.isOk()) {
+          for (let attempt = 0; attempt < maxRetries && failedIndices.length > 0; attempt++) {
+            const retryBodies = failedIndices.map((i) => batch[i]!);
+            logger.warn(
+              `amcRequestWithRetry: ${failedIndices.length}/${batch.length} requests failed, retrying (attempt ${attempt + 1}/${maxRetries})`
+            );
+            const retryResult = await this.amcRequest(retryBodies, { returnExceptions: true });
+            if (retryResult.isErr()) break;
+
+            const stillFailedIndices: number[] = [];
             for (let j = 0; j < failedIndices.length; j++) {
               const retryResp = retryResult.value[j];
               if (retryResp && !(retryResp instanceof WikidotError)) {
-                results[failedIndices[j]!] = retryResp;
+                batchResults[failedIndices[j]!] = retryResp;
               } else {
-                logger.warn(
-                  `amcRequestWithRetry: retry failed, skipping: ${retryResp instanceof WikidotError ? retryResp.message : 'unknown'}`
-                );
+                stillFailedIndices.push(failedIndices[j]!);
               }
             }
+            failedIndices = stillFailedIndices;
           }
+
+          allResults.push(...batchResults);
         }
 
-        return results;
+        const failedCount = allResults.filter((r) => r === null).length;
+        if (failedCount > 0) {
+          logger.warn(
+            `amcRequestWithRetry: ${allResults.length - failedCount}/${allResults.length} succeeded (${failedCount} failed)`
+          );
+        }
+
+        return allResults;
       })(),
       (error) => {
         if (error instanceof WikidotError) return error;

--- a/src/module/site/site.ts
+++ b/src/module/site/site.ts
@@ -149,8 +149,8 @@ export class Site {
     bodies: AMCRequestBody[],
     options?: { batchSize?: number; maxRetries?: number }
   ): WikidotResultAsync<(AMCResponse | null)[]> {
-    const batchSize = options?.batchSize ?? 50;
-    const maxRetries = options?.maxRetries ?? 3;
+    const batchSize = options?.batchSize ?? this.client.amcClient.config.retryBatchSize;
+    const maxRetries = options?.maxRetries ?? this.client.amcClient.config.retryMaxRetries;
 
     return fromPromise(
       (async () => {

--- a/src/module/site/site.ts
+++ b/src/module/site/site.ts
@@ -152,6 +152,13 @@ export class Site {
     const batchSize = options?.batchSize ?? this.client.amcClient.config.retryBatchSize;
     const maxRetries = options?.maxRetries ?? this.client.amcClient.config.retryMaxRetries;
 
+    if (!Number.isFinite(batchSize) || batchSize <= 0) {
+      throw new Error(`Invalid batchSize: ${batchSize}. Must be a positive integer.`);
+    }
+    if (!Number.isFinite(maxRetries) || maxRetries < 0) {
+      throw new Error(`Invalid maxRetries: ${maxRetries}. Must be a non-negative integer.`);
+    }
+
     return fromPromise(
       (async () => {
         const allResults: (AMCResponse | null)[] = [];

--- a/src/module/types.ts
+++ b/src/module/types.ts
@@ -95,7 +95,10 @@ export interface SiteRef {
   /**
    * Execute AMC request with partial failure tolerance
    */
-  amcRequestWithRetry(bodies: AMCRequestBody[]): WikidotResultAsync<(AMCResponse | null)[]>;
+  amcRequestWithRetry(
+    bodies: AMCRequestBody[],
+    options?: { batchSize?: number; maxRetries?: number }
+  ): WikidotResultAsync<(AMCResponse | null)[]>;
 }
 
 /**


### PR DESCRIPTION
## Summary
- `amcRequestWithRetry` に `batchSize` (デフォルト50) 単位のバッチ分割を追加
- 失敗リクエストの `maxRetries` (デフォルト3) 回リトライを追加（従来は1回固定）
- `AMCConfig` に `retryBatchSize` / `retryMaxRetries` を追加し、設定から変更可能に
- 入力バリデーション追加（正の整数チェック）、fromPromise内で実行しWikidotResultAsync契約を維持

## Test plan
- [ ] format/lint/typecheck パス確認
- [ ] 実環境（GHA/Azure US-East）でのフォーラムスレッド大量取得テスト